### PR TITLE
feat: add option to run ROMs from flash

### DIFF
--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -163,10 +163,10 @@ void Bus::saveState()
     if (!SD.exists("/states")) SD.mkdir("/states");
     uint32_t CRC32 = cart->CRC32;
 
-    char CRC32_str[9];
+    static char CRC32_str[9];
     sprintf(CRC32_str, "%08lX", (unsigned long)CRC32);
 
-    char filename[32];
+    static char filename[32];
     sprintf(filename, "/states/%s.state", CRC32_str);
 
     File state = SD.open(filename, FILE_WRITE);
@@ -189,10 +189,10 @@ void Bus::loadState()
 {
     uint32_t CRC32 = cart->CRC32;
 
-    char CRC32_str[9];
+    static char CRC32_str[9];
     sprintf(CRC32_str, "%08lX", (unsigned long)CRC32);
 
-    char filename[32];
+    static char filename[32];
     sprintf(filename, "/states/%s.state", CRC32_str);
     if (!SD.exists(filename)) return;
 
@@ -200,8 +200,8 @@ void Bus::loadState()
     if (!state) return;
 
     // Verify header
-    char header[8];
-    char CRC[9];
+    static char header[8];
+    static char CRC[9];
     state.read((uint8_t*)&header, 7);
     header[7] = '\0';
     state.read((uint8_t*)&CRC, 8);

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -1,7 +1,7 @@
 #include "cartridge.h"
 #include "bus.h"
 
-Cartridge::Cartridge(const char* filename)
+Cartridge::Cartridge(const char* filename, ROMBackend backend)
 {
     struct cartridge_header
     {
@@ -26,6 +26,8 @@ Cartridge::Cartridge(const char* filename)
     mapper_ID = (header.mapper2 & 0xF0) | header.mapper1 >> 4;
     hardware_mirror = (header.mapper1 & 0x01) ? VERTICAL : HORIZONTAL;
 
+    uint8_t number_PRG_banks = 0;
+    uint8_t number_CHR_banks = 0;
     // Check file format
     uint8_t file_type = 1;
     // if ((header.mapper2 & 0x0C) == 0x08);
@@ -43,6 +45,9 @@ Cartridge::Cartridge(const char* filename)
     default: break;
     }
 
+    prg_base = sizeof(cartridge_header) + (header.mapper1 & 0x04 ? 512 : 0);
+    chr_base = prg_base + (number_PRG_banks * 16384);
+
     // Calculate ROM CRC32
     {
         uint8_t buf[4096];
@@ -53,18 +58,12 @@ Cartridge::Cartridge(const char* filename)
         LOGF("CRC32: %08lX\n", (unsigned int)CRC32);
     }
 
-    prg_base = sizeof(cartridge_header) + (header.mapper1 & 0x04 ? 512 : 0);
-    chr_base = prg_base + (number_PRG_banks * 16384);
-    switch (mapper_ID)
+    if (backend == ROMBackend::FLASH)
     {
-    case 0: mapper = createMapper000(number_PRG_banks, number_CHR_banks, this); break;
-    case 1: mapper = createMapper001(number_PRG_banks, number_CHR_banks, this); break;
-    case 2: mapper = createMapper002(number_PRG_banks, number_CHR_banks, this); break;
-    case 3: mapper = createMapper003(number_PRG_banks, number_CHR_banks, this); break;
-    case 4: mapper = createMapper004(number_PRG_banks, number_CHR_banks, this); break;
-    case 69: mapper = createMapper069(number_PRG_banks, number_CHR_banks, this); break;
-    default: is_valid = false; break;
+        mappedROM_init(&mROM, this, CRC32, number_PRG_banks, number_CHR_banks);
     }
+    createMapper(number_PRG_banks, number_CHR_banks, backend);
+    LOG("Cartridge Initialized");
 }
 
 Cartridge::~Cartridge()
@@ -233,6 +232,30 @@ void Cartridge::loadState(File& state)
 bool Cartridge::isValid()
 {
     return is_valid;
+}
+
+void Cartridge::seek(uint32_t offset)
+{
+    rom.seek(offset);
+}
+
+void Cartridge::read(uint8_t* buf, size_t size)
+{
+    rom.read(buf, size);
+}
+
+void Cartridge::createMapper(uint8_t number_PRG_banks, uint8_t number_CHR_banks, ROMBackend backend)
+{
+    switch (mapper_ID)
+    {
+    case 0: mapper = createMapper000(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 1: mapper = createMapper001(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 2: mapper = createMapper002(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 3: mapper = createMapper003(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 4: mapper = createMapper004(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 69: mapper = createMapper069(number_PRG_banks, number_CHR_banks, backend, this); break;
+    default: is_valid = false; break;
+    }
 }
 
 uint32_t Cartridge::crc32(const void* buf, size_t size, uint32_t seed)

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -70,7 +70,7 @@ Cartridge::~Cartridge()
 {
 }
 
-IRAM_ATTR bool Cartridge::cpuRead(uint16_t addr, uint8_t& data)
+bool Cartridge::cpuRead(uint16_t addr, uint8_t& data)
 {
     switch (mapper_ID)
     {
@@ -84,7 +84,7 @@ IRAM_ATTR bool Cartridge::cpuRead(uint16_t addr, uint8_t& data)
     }
 }
 
-IRAM_ATTR bool Cartridge::cpuWrite(uint16_t addr, uint8_t data)
+bool Cartridge::cpuWrite(uint16_t addr, uint8_t data)
 {
     switch (mapper_ID)
     {
@@ -98,7 +98,7 @@ IRAM_ATTR bool Cartridge::cpuWrite(uint16_t addr, uint8_t data)
     }
 }
 
-IRAM_ATTR bool Cartridge::ppuRead(uint16_t addr, uint8_t& data)
+bool Cartridge::ppuRead(uint16_t addr, uint8_t& data)
 {
     switch (mapper_ID)
     {
@@ -112,7 +112,7 @@ IRAM_ATTR bool Cartridge::ppuRead(uint16_t addr, uint8_t& data)
     }
 }
 
-IRAM_ATTR bool Cartridge::ppuWrite(uint16_t addr, uint8_t data)
+bool Cartridge::ppuWrite(uint16_t addr, uint8_t data)
 {
     switch (mapper_ID)
     {
@@ -126,7 +126,7 @@ IRAM_ATTR bool Cartridge::ppuWrite(uint16_t addr, uint8_t data)
     }
 }
 
-IRAM_ATTR uint8_t* Cartridge::ppuReadPtr(uint16_t addr)
+uint8_t* Cartridge::ppuReadPtr(uint16_t addr)
 {
     switch (mapper_ID)
     {

--- a/src/core/cartridge.h
+++ b/src/core/cartridge.h
@@ -5,6 +5,7 @@
 #include <SPI.h>
 #include <vector>
 
+#include "../flash_mmap.h"
 #include "mapper.h"
 #include "mappers/mapper000.h"
 #include "mappers/mapper001.h"
@@ -12,12 +13,13 @@
 #include "mappers/mapper003.h"
 #include "mappers/mapper004.h"
 #include "mappers/mapper069.h"
+#include "rom_backends.h"
 
 class Bus;
 class Cartridge
 {
 public:
-    Cartridge(const char* filename);
+    Cartridge(const char* filename, ROMBackend backend = ROMBackend::LRU);
     ~Cartridge();
 
     enum MIRROR : uint8_t
@@ -52,9 +54,13 @@ public:
     void loadState(File& state);
     bool isValid();
 
+    void seek(uint32_t offset);
+    void read(uint8_t* buf, size_t size);
+
     uint8_t hardware_mirror;
     uint8_t mirror = HORIZONTAL;
     uint32_t CRC32 = ~0U;
+    MappedROM mROM;
 
 private:
     Bus* bus = nullptr;
@@ -65,9 +71,7 @@ private:
     File rom;
     Mapper mapper;
     uint8_t mapper_ID = 0;
-    uint8_t number_PRG_banks = 0;
-    uint8_t number_CHR_banks = 0;
-
+    void createMapper(uint8_t number_PRG_banks, uint8_t number_CHR_banks, ROMBackend backend);
     uint32_t crc32(const void* buf, size_t size, uint32_t seed = ~0U);
 };
 

--- a/src/core/cartridge.h
+++ b/src/core/cartridge.h
@@ -19,7 +19,7 @@ class Bus;
 class Cartridge
 {
 public:
-    Cartridge(const char* filename, ROMBackend backend = ROMBackend::LRU);
+    Cartridge(const char* filename, ROMBackend backend = ROMBackend::FLASH);
     ~Cartridge();
 
     enum MIRROR : uint8_t

--- a/src/core/cartridge.h
+++ b/src/core/cartridge.h
@@ -19,7 +19,7 @@ class Bus;
 class Cartridge
 {
 public:
-    Cartridge(const char* filename, ROMBackend backend = ROMBackend::FLASH);
+    Cartridge(const char* filename, ROMBackend backend = ROMBackend::LRU);
     ~Cartridge();
 
     enum MIRROR : uint8_t

--- a/src/core/mapper.cpp
+++ b/src/core/mapper.cpp
@@ -25,7 +25,7 @@ void bankInit(BankCache* cache, Bank* banks, uint8_t num_banks, uint32_t bank_si
     }
 }
 
-IRAM_ATTR uint8_t* getBank(BankCache* cache, uint8_t bank_id, Mapper::ROM_TYPE rom)
+IRAM_ATTR uint8_t* getBank(BankCache* cache, uint8_t bank_id, RomType rom)
 {
     cache->tick++;
 
@@ -51,8 +51,8 @@ IRAM_ATTR uint8_t* getBank(BankCache* cache, uint8_t bank_id, Mapper::ROM_TYPE r
 
     uint8_t* bank = cache->banks[bank_index].bank_ptr;
     uint32_t size = cache->banks[bank_index].size;
-    if (rom == Mapper::ROM_TYPE::PRG_ROM) cache->cart->loadPRGBank(bank, size, bank_id * size);
-    else if (rom == Mapper::ROM_TYPE::CHR_ROM) cache->cart->loadCHRBank(bank, size, bank_id * size);
+    if (rom == RomType::PRG) cache->cart->loadPRGBank(bank, size, bank_id * size);
+    else if (rom == RomType::CHR) cache->cart->loadCHRBank(bank, size, bank_id * size);
 
     cache->banks[bank_index].bank_id = bank_id;
     cache->banks[bank_index].last_used = cache->tick;

--- a/src/core/mapper.h
+++ b/src/core/mapper.h
@@ -7,19 +7,16 @@
 #include <stdlib.h>
 
 #include "../debug.h"
+#include "../flash_mmap.h"
 #include "Arduino.h"
 #include "config.h"
+#include "rom_backends.h"
+#include "rom_types.h"
 
 class Cartridge;
 class Mapper
 {
 public:
-    enum ROM_TYPE : uint8_t
-    {
-        PRG_ROM,
-        CHR_ROM
-    };
-
     void* state = nullptr;
 };
 
@@ -48,7 +45,7 @@ struct BankCache
 
 void bankInit(BankCache* cache, Bank* banks, uint8_t num_banks, uint32_t bank_size,
               Cartridge* cart);
-uint8_t* getBank(BankCache* cache, uint8_t bank_id, Mapper::ROM_TYPE rom);
+uint8_t* getBank(BankCache* cache, uint8_t bank_id, RomType rom);
 uint8_t getBankIndex(BankCache* cache, uint8_t* ptr);
 void invalidateCache(BankCache* cache);
 

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -13,11 +13,6 @@ IRAM_ATTR bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    return false;
-}
-
 IRAM_ATTR bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
@@ -53,40 +48,84 @@ IRAM_ATTR uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr)
 void mapper000_reset(Mapper* mapper)
 {
     Mapper000_state* state = (Mapper000_state*)mapper->state;
-    state->PRG_banks[0] = &state->PRG_ROM[0];
-    state->PRG_banks[1] =
-        (state->number_PRG_banks > 1) ? &state->PRG_ROM[16U * 1024U] : &state->PRG_ROM[0];
-    state->CHR_bank = &state->CHR_ROM[0];
+    switch (state->backend)
+    {
+    case ROMBackend::LRU:
+        state->PRG_banks[0] = &state->PRG_ROM[0];
+        state->PRG_banks[1] =
+            (state->number_PRG_banks > 1) ? &state->PRG_ROM[16U * 1024U] : &state->PRG_ROM[0];
+        state->CHR_bank = &state->CHR_ROM[0];
 
-    state->cart->loadPRGBank(state->PRG_banks[0], 16U * 1024U, 0);
-    if (state->number_PRG_banks > 1)
-        state->cart->loadPRGBank(state->PRG_banks[1], 16U * 1024U, 16U * 1024U);
-    state->cart->loadCHRBank(state->CHR_bank, 8U * 1024U, 0);
+        state->cart->loadPRGBank(state->PRG_banks[0], 16U * 1024U, 0);
+        if (state->number_PRG_banks > 1)
+            state->cart->loadPRGBank(state->PRG_banks[1], 16U * 1024U, 16U * 1024U);
+        state->cart->loadCHRBank(state->CHR_bank, 16U * 1024U, 0);
+        break;
+    case ROMBackend::FLASH:
+        state->PRG_banks[0] = (uint8_t*)state->mROM->prg_base;
+        state->PRG_banks[1] = (state->number_PRG_banks > 1)
+                                  ? (uint8_t*)(state->mROM->prg_base + (16U * 1024U))
+                                  : (uint8_t*)state->mROM->prg_base;
+        state->CHR_bank =
+            (state->number_CHR_banks == 0) ? state->CHR_ROM : (uint8_t*)state->mROM->chr_base;
+    }
 }
 
 void mapper000_dumpState(Mapper* mapper, File& state)
 {
     Mapper000_state* s = (Mapper000_state*)mapper->state;
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+        if (s->number_CHR_banks == 0 && s->CHR_bank) { state.write(s->CHR_bank, 8U * 1024U); }
+        return;
 
-    if (s->number_CHR_banks == 0 && s->CHR_bank) { state.write(s->CHR_bank, 8U * 1024U); }
+    case ROMBackend::FLASH: return;
+    }
 }
 
 void mapper000_loadState(Mapper* mapper, File& state)
 {
     Mapper000_state* s = (Mapper000_state*)mapper->state;
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+        if (s->number_CHR_banks == 0 && s->CHR_bank) { state.read(s->CHR_bank, 8U * 1024U); }
+        return;
 
-    if (s->number_CHR_banks == 0 && s->CHR_bank) { state.read(s->CHR_bank, 8U * 1024U); }
+    case ROMBackend::FLASH: return;
+    }
 }
 
-Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart)
+Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
-
     Mapper000_state* state = new Mapper000_state;
+    switch (backend)
+    {
+    case ROMBackend::LRU:
+        state->PRG_ROM = (uint8_t*)malloc(32 * 1024);
+        if (state->PRG_ROM)
+            LOGF("Allocated 32 KB for PRG ROM, free heap: %u bytes\n",
+                 heap_caps_get_free_size(MALLOC_CAP_DEFAULT));
+        else LOG("32 KB for PRG ROM Allocation failed.");
+
+        state->CHR_ROM = (uint8_t*)malloc(16U * 1024U);
+        if (state->CHR_ROM)
+            LOGF("Allocated 8 KB for CHR ROM, free heap: %u bytes\n",
+                 heap_caps_get_free_size(MALLOC_CAP_DEFAULT));
+        else LOG("8 KB for CHR ROM Allocation failed.");
+        break;
+    case ROMBackend::FLASH:
+        if (CHR_banks == 0) state->CHR_ROM = (uint8_t*)malloc(8U * 1024U);
+        state->mROM = &cart->mROM;
+        break;
+    }
+
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;
     state->cart = cart;
-
+    state->backend = backend;
     mapper.state = state;
     return mapper;
 }

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -13,6 +13,11 @@ IRAM_ATTR bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
+IRAM_ATTR bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+{
+    return false;
+}
+
 IRAM_ATTR bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -42,7 +42,7 @@ bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr)
+uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
     if (addr > 0x1FFF) return nullptr;
 

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -1,7 +1,7 @@
 #include "mapper000.h"
 #include "../cartridge.h"
 
-IRAM_ATTR bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr < 0x8000) return false;
 
@@ -13,12 +13,12 @@ IRAM_ATTR bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     return false;
 }
 
-IRAM_ATTR bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
 
@@ -27,7 +27,7 @@ IRAM_ATTR bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr > 0x1FFF) return false;
 

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -79,27 +79,15 @@ void mapper000_reset(Mapper* mapper)
 void mapper000_dumpState(Mapper* mapper, File& state)
 {
     Mapper000_state* s = (Mapper000_state*)mapper->state;
-    switch (s->backend)
-    {
-    case ROMBackend::LRU:
-        if (s->number_CHR_banks == 0 && s->CHR_bank) { state.write(s->CHR_bank, 8U * 1024U); }
-        return;
-
-    case ROMBackend::FLASH: return;
-    }
+    if (s->number_CHR_banks == 0 && s->CHR_bank) state.write(s->CHR_bank, 8U * 1024U);
+    return;
 }
 
 void mapper000_loadState(Mapper* mapper, File& state)
 {
     Mapper000_state* s = (Mapper000_state*)mapper->state;
-    switch (s->backend)
-    {
-    case ROMBackend::LRU:
-        if (s->number_CHR_banks == 0 && s->CHR_bank) { state.read(s->CHR_bank, 8U * 1024U); }
-        return;
-
-    case ROMBackend::FLASH: return;
-    }
+    if (s->number_CHR_banks == 0 && s->CHR_bank) state.read(s->CHR_bank, 8U * 1024U);
+    return;
 }
 
 Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)

--- a/src/core/mappers/mapper000.h
+++ b/src/core/mappers/mapper000.h
@@ -6,18 +6,19 @@
 struct Mapper000_state
 {
     Cartridge* cart;
+    MappedROM* mROM;
+    ROMBackend backend;
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
-    uint8_t PRG_ROM[32 * 1024];
-    uint8_t CHR_ROM[8U * 1024U];
+    uint8_t* PRG_ROM;
+    uint8_t* CHR_ROM;
     uint8_t* CHR_bank;
     uint8_t* PRG_banks[2];
 };
 
-Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart);
+Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper000.h
+++ b/src/core/mappers/mapper000.h
@@ -19,6 +19,7 @@ struct Mapper000_state
 Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
+bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -272,25 +272,24 @@ void mapper001_reset(Mapper* mapper)
 void mapper001_dumpState(Mapper* mapper, File& state)
 {
     Mapper001_state* s = (Mapper001_state*)mapper->state;
+    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+    state.write((uint8_t*)&s->load, sizeof(s->load));
+    state.write((uint8_t*)&s->control, sizeof(s->control));
+    state.write((uint8_t*)&s->load_writes, sizeof(s->load_writes));
+    state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+    state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+    state.write((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
+    state.write((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
+    state.write((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
+    state.write((uint8_t*)&mirror, sizeof(mirror));
+    state.write(s->RAM, 8U * 1024U);
+
+    uint8_t PRG_16K[4];
+    uint8_t CHR_8K;
+    uint8_t CHR_4K[2];
     switch (s->backend)
     {
     case ROMBackend::LRU:
-    {
-        Cartridge::MIRROR mirror = s->cart->getMirrorMode();
-        state.write((uint8_t*)&s->load, sizeof(s->load));
-        state.write((uint8_t*)&s->control, sizeof(s->control));
-        state.write((uint8_t*)&s->load_writes, sizeof(s->load_writes));
-        state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-        state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-        state.write((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
-        state.write((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
-        state.write((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
-        state.write((uint8_t*)&mirror, sizeof(mirror));
-        state.write(s->RAM, 8U * 1024U);
-
-        uint8_t PRG_16K[4];
-        uint8_t CHR_8K;
-        uint8_t CHR_4K[2];
         for (int i = 0; i < 4; i++)
             PRG_16K[i] = getBankIndex(&s->PRG_16K_cache, s->ptr_16K_PRG_banks[i]);
         state.write(PRG_16K, sizeof(PRG_16K));
@@ -305,34 +304,50 @@ void mapper001_dumpState(Mapper* mapper, File& state)
             state.write(CHR_4K, sizeof(CHR_4K));
         }
         return;
-    }
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        for (int i = 0; i < 4; i++)
+        {
+            PRG_16K[i] = (s->ptr_16K_PRG_banks[i] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
+        }
+        state.write(PRG_16K, sizeof(PRG_16K));
+
+        if (s->number_CHR_banks == 0) { state.write(s->CHR_RAM, 8U * 1024U); }
+        else
+        {
+            CHR_8K = (s->ptr_8K_CHR_bank - (uint8_t*)s->mROM->chr_base) / (8U * 1024U);
+            for (int i = 0; i < 2; i++)
+                CHR_4K[i] = (s->ptr_4K_CHR_banks[i] - (uint8_t*)s->mROM->chr_base) / (4U * 1024U);
+
+            state.write((uint8_t*)&CHR_8K, sizeof(CHR_8K));
+            state.write(CHR_4K, sizeof(CHR_4K));
+        }
+        return;
     }
 }
 
 void mapper001_loadState(Mapper* mapper, File& state)
 {
     Mapper001_state* s = (Mapper001_state*)mapper->state;
+    Cartridge::MIRROR mirror;
+    state.read((uint8_t*)&s->load, sizeof(s->load));
+    state.read((uint8_t*)&s->control, sizeof(s->control));
+    state.read((uint8_t*)&s->load_writes, sizeof(s->load_writes));
+    state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+    state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+    state.read((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
+    state.read((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
+    state.read((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
+    state.read((uint8_t*)&mirror, sizeof(mirror));
+    state.read(s->RAM, 8U * 1024U);
+    s->cart->setMirrorMode(mirror);
+
+    uint8_t PRG_16K[4];
+    uint8_t CHR_8K;
+    uint8_t CHR_4K[2];
     switch (s->backend)
     {
     case ROMBackend::LRU:
-        Cartridge::MIRROR mirror;
-        state.read((uint8_t*)&s->load, sizeof(s->load));
-        state.read((uint8_t*)&s->control, sizeof(s->control));
-        state.read((uint8_t*)&s->load_writes, sizeof(s->load_writes));
-        state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-        state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-        state.read((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
-        state.read((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
-        state.read((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
-        state.read((uint8_t*)&mirror, sizeof(mirror));
-        state.read(s->RAM, 8U * 1024U);
-        s->cart->setMirrorMode(mirror);
-
-        uint8_t PRG_16K[4];
-        uint8_t CHR_8K;
-        uint8_t CHR_4K[2];
         state.read(PRG_16K, sizeof(PRG_16K));
         invalidateCache(&s->PRG_16K_cache);
         for (int i = 0; i < 4; i++)
@@ -351,7 +366,26 @@ void mapper001_loadState(Mapper* mapper, File& state)
         }
         return;
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        state.read(PRG_16K, sizeof(PRG_16K));
+        for (int i = 0; i < 4; i++)
+        {
+            s->ptr_16K_PRG_banks[i] =
+                (uint8_t*)(s->mROM->prg_base + (uint32_t)PRG_16K[i] * (16U * 1024U));
+        }
+
+        if (s->number_CHR_banks == 0) { state.read(s->CHR_RAM, (8U * 1024U)); }
+        else
+        {
+            state.read((uint8_t*)&CHR_8K, sizeof(CHR_8K));
+            state.read(CHR_4K, sizeof(CHR_4K));
+
+            s->ptr_8K_CHR_bank = (uint8_t*)(s->mROM->chr_base + (uint32_t)CHR_8K * (8U * 1024U));
+            for (int i = 0; i < 2; i++)
+                s->ptr_4K_CHR_banks[i] =
+                    (uint8_t*)(s->mROM->chr_base + (uint32_t)CHR_4K[i] * (4U * 1024U));
+        }
+        return;
     }
 }
 

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -196,7 +196,7 @@ bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr)
+uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
     if (addr > 0x1FFF) return nullptr;
 

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -393,8 +393,6 @@ Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
 {
     Mapper mapper;
     Mapper001_state* state = new Mapper001_state;
-    state->RAM = (uint8_t*)malloc(8U * 1024U);
-
     switch (backend)
     {
     case ROMBackend::LRU:
@@ -426,6 +424,7 @@ Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
         break;
     }
 
+    state->RAM = (uint8_t*)malloc(8U * 1024U);
     state->backend = backend;
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -393,6 +393,8 @@ Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
 {
     Mapper mapper;
     Mapper001_state* state = new Mapper001_state;
+    state->RAM = (uint8_t*)malloc(8U * 1024U);
+
     switch (backend)
     {
     case ROMBackend::LRU:
@@ -424,7 +426,6 @@ Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
         break;
     }
 
-    state->RAM = (uint8_t*)malloc(8U * 1024U);
     state->backend = backend;
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -4,6 +4,8 @@
 struct Mapper001_state
 {
     Cartridge* cart;
+    MappedROM* mROM;
+    ROMBackend backend;
     uint8_t* RAM;
     uint8_t* CHR_RAM;
 
@@ -37,6 +39,11 @@ struct Mapper001_state
                                                      Cartridge::MIRROR::HORIZONTAL };
 };
 constexpr Cartridge::MIRROR Mapper001_state::mirror[4];
+static inline uint8_t* getPRGBank(Mapper001_state* state, uint8_t index);
+static inline uint8_t* getCHRBank8K(Mapper001_state* state, uint8_t index);
+static inline uint8_t* getCHRBank4K(Mapper001_state* state, uint8_t index);
+static inline void loadCHRRAM(Mapper001_state* state, uint8_t* bank, uint16_t size,
+                              uint32_t offset);
 
 IRAM_ATTR bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
@@ -99,21 +106,16 @@ IRAM_ATTR bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 if (state->CHR_ROM_bank_mode == 0)
                 {
                     if (state->number_CHR_banks == 0)
-                        state->cart->loadCHRBank(state->ptr_8K_CHR_bank, 8U * 1024U,
-                                                 (state->CHR_bank_0 & 0x1E) * 8U * 1024U);
-                    else
-                        state->ptr_8K_CHR_bank =
-                            getBank(&state->CHR_8K_cache, state->CHR_bank_0 & 0x1E,
-                                    Mapper::ROM_TYPE::CHR_ROM);
+                        loadCHRRAM(state, state->ptr_8K_CHR_bank, 16U * 1024U,
+                                   (state->CHR_bank_0 & 0x1E) * 16U * 1024U);
+                    else state->ptr_8K_CHR_bank = getCHRBank8K(state, state->CHR_bank_0 & 0x1E);
                 }
                 else
                 {
                     if (state->number_CHR_banks == 0)
-                        state->cart->loadCHRBank(state->ptr_4K_CHR_banks[0], 4 * 1024,
-                                                 state->CHR_bank_0 * 4 * 1024);
-                    else
-                        state->ptr_4K_CHR_banks[0] = getBank(
-                            &state->CHR_4K_cache, state->CHR_bank_0, Mapper::ROM_TYPE::CHR_ROM);
+                        loadCHRRAM(state, state->ptr_4K_CHR_banks[0], 4U * 1024,
+                                   state->CHR_bank_0 * 4U * 1024);
+                    else state->ptr_4K_CHR_banks[0] = getCHRBank4K(state, state->CHR_bank_0);
                 }
                 break;
 
@@ -124,11 +126,9 @@ IRAM_ATTR bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 if (state->CHR_ROM_bank_mode == 1)
                 {
                     if (state->number_CHR_banks == 0)
-                        state->cart->loadCHRBank(state->ptr_4K_CHR_banks[1], 4 * 1024,
-                                                 state->CHR_bank_1 * 4 * 1024);
-                    else
-                        state->ptr_4K_CHR_banks[1] = getBank(
-                            &state->CHR_4K_cache, state->CHR_bank_1, Mapper::ROM_TYPE::CHR_ROM);
+                        loadCHRRAM(state, state->ptr_4K_CHR_banks[1], 4U * 1024,
+                                   state->CHR_bank_1 * 4U * 1024);
+                    else state->ptr_4K_CHR_banks[1] = getCHRBank4K(state, state->CHR_bank_1);
                 }
                 break;
 
@@ -140,24 +140,16 @@ IRAM_ATTR bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 {
                 case 0:
                 case 1:
-                    state->ptr_16K_PRG_banks[2] = getBank(
-                        &state->PRG_16K_cache, state->PRG_bank & 0x0E, Mapper::ROM_TYPE::PRG_ROM);
-                    state->ptr_16K_PRG_banks[3] =
-                        getBank(&state->PRG_16K_cache, (state->PRG_bank & 0x0E) + 1,
-                                Mapper::ROM_TYPE::PRG_ROM);
+                    state->ptr_16K_PRG_banks[2] = getPRGBank(state, state->PRG_bank & 0x0E);
+                    state->ptr_16K_PRG_banks[3] = getPRGBank(state, (state->PRG_bank & 0x0E) + 1);
                     break;
                 case 2:
-                    state->ptr_16K_PRG_banks[0] =
-                        getBank(&state->PRG_16K_cache, 0, Mapper::ROM_TYPE::PRG_ROM);
-                    state->ptr_16K_PRG_banks[1] = getBank(
-                        &state->PRG_16K_cache, state->PRG_bank & 0x0F, Mapper::ROM_TYPE::PRG_ROM);
+                    state->ptr_16K_PRG_banks[0] = getPRGBank(state, 0);
+                    state->ptr_16K_PRG_banks[1] = getPRGBank(state, state->PRG_bank & 0x0F);
                     break;
                 case 3:
-                    state->ptr_16K_PRG_banks[0] = getBank(
-                        &state->PRG_16K_cache, state->PRG_bank & 0x0F, Mapper::ROM_TYPE::PRG_ROM);
-                    state->ptr_16K_PRG_banks[1] =
-                        getBank(&state->PRG_16K_cache, state->number_PRG_banks - 1,
-                                Mapper::ROM_TYPE::PRG_ROM);
+                    state->ptr_16K_PRG_banks[0] = getPRGBank(state, state->PRG_bank & 0x0F);
+                    state->ptr_16K_PRG_banks[1] = getPRGBank(state, state->number_PRG_banks - 1);
                     break;
                 default: break;
                 }
@@ -209,34 +201,62 @@ IRAM_ATTR uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr)
     if (addr > 0x1FFF) return nullptr;
 
     Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (state->CHR_ROM_bank_mode == 0) { return &state->ptr_8K_CHR_bank[addr & 0x1FFF]; }
-    else { return &state->ptr_4K_CHR_banks[(addr >> 12) & 1][addr & 0x0FFF]; }
+    if (state->CHR_ROM_bank_mode == 0) return &state->ptr_8K_CHR_bank[addr & 0x1FFF];
+    else return &state->ptr_4K_CHR_banks[(addr >> 12) & 1][addr & 0x0FFF];
 }
 
 void mapper001_reset(Mapper* mapper)
 {
     Mapper001_state* state = (Mapper001_state*)mapper->state;
     memset(state->RAM, 0, 8U * 1024U);
+    if (state->CHR_RAM) memset(state->CHR_RAM, 0, 8U * 1024U);
 
-    if (state->number_CHR_banks == 0)
+    switch (state->backend)
     {
-        // Point 4K banks into the same memory
-        state->ptr_8K_CHR_bank = state->CHR_RAM;
-        state->ptr_4K_CHR_banks[0] = state->CHR_RAM;
-        state->ptr_4K_CHR_banks[1] = state->CHR_RAM + 0x1000;
-    }
-    else
-    {
-        state->ptr_8K_CHR_bank = getBank(&state->CHR_8K_cache, 0, Mapper::ROM_TYPE::CHR_ROM);
-        state->ptr_4K_CHR_banks[0] = getBank(&state->CHR_4K_cache, 0, Mapper::ROM_TYPE::CHR_ROM);
-        state->ptr_4K_CHR_banks[1] = getBank(&state->CHR_4K_cache, 1, Mapper::ROM_TYPE::CHR_ROM);
-    }
+    case ROMBackend::LRU:
+        if (state->number_CHR_banks == 0)
+        {
+            // Point 4K banks into the same memory
+            state->ptr_8K_CHR_bank = state->CHR_RAM;
+            state->ptr_4K_CHR_banks[0] = state->CHR_RAM;
+            state->ptr_4K_CHR_banks[1] = state->CHR_RAM + 0x1000;
+        }
+        else
+        {
+            state->ptr_8K_CHR_bank = getBank(&state->CHR_8K_cache, 0, RomType::CHR);
+            state->ptr_4K_CHR_banks[0] = getBank(&state->CHR_4K_cache, 0, RomType::CHR);
+            state->ptr_4K_CHR_banks[1] = getBank(&state->CHR_4K_cache, 1, RomType::CHR);
+        }
 
-    state->ptr_16K_PRG_banks[0] = getBank(&state->PRG_16K_cache, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_16K_PRG_banks[1] =
-        getBank(&state->PRG_16K_cache, state->number_PRG_banks - 1, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_16K_PRG_banks[2] = getBank(&state->PRG_16K_cache, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_16K_PRG_banks[3] = getBank(&state->PRG_16K_cache, 1, Mapper::ROM_TYPE::PRG_ROM);
+        state->ptr_16K_PRG_banks[0] = getBank(&state->PRG_16K_cache, 0, RomType::PRG);
+        state->ptr_16K_PRG_banks[1] =
+            getBank(&state->PRG_16K_cache, state->number_PRG_banks - 1, RomType::PRG);
+        state->ptr_16K_PRG_banks[2] = getBank(&state->PRG_16K_cache, 0, RomType::PRG);
+        state->ptr_16K_PRG_banks[3] = getBank(&state->PRG_16K_cache, 1, RomType::PRG);
+        break;
+
+    case ROMBackend::FLASH:
+        if (state->number_CHR_banks == 0)
+        {
+            // Point 4K banks into the same memory
+            state->ptr_8K_CHR_bank = state->CHR_RAM;
+            state->ptr_4K_CHR_banks[0] = state->CHR_RAM;
+            state->ptr_4K_CHR_banks[1] = state->CHR_RAM + 0x1000;
+        }
+        else
+        {
+            state->ptr_8K_CHR_bank = (uint8_t*)state->mROM->chr_base;
+            state->ptr_4K_CHR_banks[0] = (uint8_t*)state->mROM->chr_base;
+            state->ptr_4K_CHR_banks[1] = (uint8_t*)state->mROM->chr_base;
+        }
+
+        state->ptr_16K_PRG_banks[0] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_16K_PRG_banks[1] =
+            (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - (16U * 1024U)));
+        state->ptr_16K_PRG_banks[2] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_16K_PRG_banks[3] = (uint8_t*)(state->mROM->prg_base + (16U * 1024U));
+        break;
+    }
 
     state->load = 0x00;
     state->control = 0x1C;
@@ -252,101 +272,158 @@ void mapper001_reset(Mapper* mapper)
 void mapper001_dumpState(Mapper* mapper, File& state)
 {
     Mapper001_state* s = (Mapper001_state*)mapper->state;
-    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
-    state.write((uint8_t*)&s->load, sizeof(s->load));
-    state.write((uint8_t*)&s->control, sizeof(s->control));
-    state.write((uint8_t*)&s->load_writes, sizeof(s->load_writes));
-    state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-    state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-    state.write((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
-    state.write((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
-    state.write((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
-    state.write((uint8_t*)&mirror, sizeof(mirror));
-    state.write(s->RAM, 8U * 1024U);
-
-    uint8_t PRG_16K[4];
-    uint8_t CHR_8K;
-    uint8_t CHR_4K[2];
-    for (int i = 0; i < 4; i++)
-        PRG_16K[i] = getBankIndex(&s->PRG_16K_cache, s->ptr_16K_PRG_banks[i]);
-    state.write(PRG_16K, sizeof(PRG_16K));
-    if (s->number_CHR_banks == 0) { state.write(s->CHR_RAM, 8U * 1024U); }
-    else
+    switch (s->backend)
     {
-        CHR_8K = getBankIndex(&s->CHR_8K_cache, s->ptr_8K_CHR_bank);
-        for (int i = 0; i < 2; i++)
-            CHR_4K[i] = getBankIndex(&s->CHR_4K_cache, s->ptr_4K_CHR_banks[i]);
+    case ROMBackend::LRU:
+    {
+        Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+        state.write((uint8_t*)&s->load, sizeof(s->load));
+        state.write((uint8_t*)&s->control, sizeof(s->control));
+        state.write((uint8_t*)&s->load_writes, sizeof(s->load_writes));
+        state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+        state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+        state.write((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
+        state.write((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
+        state.write((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
+        state.write((uint8_t*)&mirror, sizeof(mirror));
+        state.write(s->RAM, 8U * 1024U);
 
-        state.write((uint8_t*)&CHR_8K, sizeof(CHR_8K));
-        state.write(CHR_4K, sizeof(CHR_4K));
+        uint8_t PRG_16K[4];
+        uint8_t CHR_8K;
+        uint8_t CHR_4K[2];
+        for (int i = 0; i < 4; i++)
+            PRG_16K[i] = getBankIndex(&s->PRG_16K_cache, s->ptr_16K_PRG_banks[i]);
+        state.write(PRG_16K, sizeof(PRG_16K));
+        if (s->number_CHR_banks == 0) { state.write(s->CHR_RAM, 8U * 1024U); }
+        else
+        {
+            CHR_8K = getBankIndex(&s->CHR_8K_cache, s->ptr_8K_CHR_bank);
+            for (int i = 0; i < 2; i++)
+                CHR_4K[i] = getBankIndex(&s->CHR_4K_cache, s->ptr_4K_CHR_banks[i]);
+
+            state.write((uint8_t*)&CHR_8K, sizeof(CHR_8K));
+            state.write(CHR_4K, sizeof(CHR_4K));
+        }
+        return;
+    }
+
+    case ROMBackend::FLASH: return;
     }
 }
 
 void mapper001_loadState(Mapper* mapper, File& state)
 {
     Mapper001_state* s = (Mapper001_state*)mapper->state;
-    Cartridge::MIRROR mirror;
-    state.read((uint8_t*)&s->load, sizeof(s->load));
-    state.read((uint8_t*)&s->control, sizeof(s->control));
-    state.read((uint8_t*)&s->load_writes, sizeof(s->load_writes));
-    state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-    state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-    state.read((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
-    state.read((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
-    state.read((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
-    state.read((uint8_t*)&mirror, sizeof(mirror));
-    state.read(s->RAM, 8U * 1024U);
-    s->cart->setMirrorMode(mirror);
-
-    uint8_t PRG_16K[4];
-    uint8_t CHR_8K;
-    uint8_t CHR_4K[2];
-    state.read(PRG_16K, sizeof(PRG_16K));
-    invalidateCache(&s->PRG_16K_cache);
-    for (int i = 0; i < 4; i++)
-        s->ptr_16K_PRG_banks[i] = getBank(&s->PRG_16K_cache, PRG_16K[i], Mapper::ROM_TYPE::PRG_ROM);
-    if (s->number_CHR_banks == 0) { state.read(s->CHR_RAM, 8U * 1024U); }
-    else
+    switch (s->backend)
     {
-        state.read((uint8_t*)&CHR_8K, sizeof(CHR_8K));
-        state.read(CHR_4K, sizeof(CHR_4K));
+    case ROMBackend::LRU:
+        Cartridge::MIRROR mirror;
+        state.read((uint8_t*)&s->load, sizeof(s->load));
+        state.read((uint8_t*)&s->control, sizeof(s->control));
+        state.read((uint8_t*)&s->load_writes, sizeof(s->load_writes));
+        state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+        state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+        state.read((uint8_t*)&s->CHR_bank_0, sizeof(s->CHR_bank_0));
+        state.read((uint8_t*)&s->CHR_bank_1, sizeof(s->CHR_bank_1));
+        state.read((uint8_t*)&s->PRG_bank, sizeof(s->PRG_bank));
+        state.read((uint8_t*)&mirror, sizeof(mirror));
+        state.read(s->RAM, 8U * 1024U);
+        s->cart->setMirrorMode(mirror);
 
-        invalidateCache(&s->CHR_8K_cache);
-        invalidateCache(&s->CHR_4K_cache);
-        s->ptr_8K_CHR_bank = getBank(&s->CHR_8K_cache, CHR_8K, Mapper::ROM_TYPE::CHR_ROM);
-        for (int i = 0; i < 2; i++)
-            s->ptr_4K_CHR_banks[i] =
-                getBank(&s->CHR_4K_cache, CHR_4K[i], Mapper::ROM_TYPE::CHR_ROM);
+        uint8_t PRG_16K[4];
+        uint8_t CHR_8K;
+        uint8_t CHR_4K[2];
+        state.read(PRG_16K, sizeof(PRG_16K));
+        invalidateCache(&s->PRG_16K_cache);
+        for (int i = 0; i < 4; i++)
+            s->ptr_16K_PRG_banks[i] = getBank(&s->PRG_16K_cache, PRG_16K[i], RomType::PRG);
+        if (s->number_CHR_banks == 0) { state.read(s->CHR_RAM, 8U * 1024U); }
+        else
+        {
+            state.read((uint8_t*)&CHR_8K, sizeof(CHR_8K));
+            state.read(CHR_4K, sizeof(CHR_4K));
+
+            invalidateCache(&s->CHR_8K_cache);
+            invalidateCache(&s->CHR_4K_cache);
+            s->ptr_8K_CHR_bank = getBank(&s->CHR_8K_cache, CHR_8K, RomType::CHR);
+            for (int i = 0; i < 2; i++)
+                s->ptr_4K_CHR_banks[i] = getBank(&s->CHR_4K_cache, CHR_4K[i], RomType::CHR);
+        }
+        return;
+
+    case ROMBackend::FLASH: return;
     }
 }
 
-Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart)
+Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
     Mapper001_state* state = new Mapper001_state;
+    switch (backend)
+    {
+    case ROMBackend::LRU:
+        bankInit(&state->PRG_16K_cache, state->PRG_banks_16K, MAPPER001_NUM_PRG_BANKS_16K,
+                 16U * 1024U, cart);
 
+        if (CHR_banks == 0)
+        {
+            // Allocate one shared 8 KB RAM
+            state->CHR_RAM = (uint8_t*)malloc(8U * 1024U);
+            memset(state->CHR_RAM, 0, 8U * 1024U);
+        }
+        else
+        {
+            bankInit(&state->CHR_8K_cache, state->CHR_banks_8K, MAPPER001_NUM_CHR_BANKS_8K,
+                     8U * 1024U, cart);
+            bankInit(&state->CHR_4K_cache, state->CHR_banks_4K, MAPPER001_NUM_CHR_BANKS_4K,
+                     4U * 1024, cart);
+        }
+        break;
+    case ROMBackend::FLASH:
+        state->mROM = &cart->mROM;
+        if (CHR_banks == 0)
+        {
+            // Allocate one shared 8 KB RAM
+            state->CHR_RAM = (uint8_t*)malloc(8U * 1024U);
+            memset(state->CHR_RAM, 0, 8U * 1024U);
+        }
+        break;
+    }
+
+    state->RAM = (uint8_t*)malloc(8U * 1024U);
+    state->backend = backend;
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;
     state->cart = cart;
-
-    bankInit(&state->PRG_16K_cache, state->PRG_banks_16K, MAPPER001_NUM_PRG_BANKS_16K, 16U * 1024U,
-             cart);
-    state->RAM = (uint8_t*)malloc(8U * 1024U);
-
-    if (CHR_banks == 0)
-    {
-        // Allocate one shared 8 KB RAM
-        state->CHR_RAM = (uint8_t*)malloc(8U * 1024U);
-        memset(state->CHR_RAM, 0, 8U * 1024U);
-    }
-    else
-    {
-        bankInit(&state->CHR_8K_cache, state->CHR_banks_8K, MAPPER001_NUM_CHR_BANKS_8K, 8U * 1024U,
-                 cart);
-        bankInit(&state->CHR_4K_cache, state->CHR_banks_4K, MAPPER001_NUM_CHR_BANKS_4K, 4 * 1024,
-                 cart);
-    }
-
     mapper.state = state;
     return mapper;
+}
+
+// Helper functions
+static inline uint8_t* getPRGBank(Mapper001_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->PRG_16K_cache, index, RomType::PRG);
+    return (uint8_t*)(state->mROM->prg_base + (uint32_t)index * 16U * 1024U);
+}
+
+static inline uint8_t* getCHRBank8K(Mapper001_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->CHR_8K_cache, index, RomType::CHR);
+    return (uint8_t*)(state->mROM->chr_base + (uint32_t)index * 8U * 1024U);
+}
+
+static inline uint8_t* getCHRBank4K(Mapper001_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->CHR_4K_cache, index, RomType::CHR);
+    return (uint8_t*)(state->mROM->chr_base + (uint32_t)index * 4U * 1024U);
+}
+
+static inline void loadCHRRAM(Mapper001_state* state, uint8_t* bank, uint16_t size, uint32_t offset)
+{
+    if (state->backend == ROMBackend::FLASH)
+        memcpy(bank, (uint8_t*)(state->mROM->chr_base + offset), size);
+    else state->cart->loadCHRBank(bank, size, offset);
 }

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -45,7 +45,7 @@ static inline uint8_t* getCHRBank4K(Mapper001_state* state, uint8_t index);
 static inline void loadCHRRAM(Mapper001_state* state, uint8_t* bank, uint16_t size,
                               uint32_t offset);
 
-IRAM_ATTR bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr < 0x6000) return false;
 
@@ -67,7 +67,7 @@ IRAM_ATTR bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr < 0x6000) return false;
 
@@ -171,7 +171,7 @@ IRAM_ATTR bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return true;
 }
 
-IRAM_ATTR bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
 
@@ -181,7 +181,7 @@ IRAM_ATTR bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr > 0x1FFF) return false;
 

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -106,8 +106,8 @@ IRAM_ATTR bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 if (state->CHR_ROM_bank_mode == 0)
                 {
                     if (state->number_CHR_banks == 0)
-                        loadCHRRAM(state, state->ptr_8K_CHR_bank, 16U * 1024U,
-                                   (state->CHR_bank_0 & 0x1E) * 16U * 1024U);
+                        loadCHRRAM(state, state->ptr_8K_CHR_bank, 8U * 1024U,
+                                   (state->CHR_bank_0 & 0x1E) * 8U * 1024U);
                     else state->ptr_8K_CHR_bank = getCHRBank8K(state, state->CHR_bank_0 & 0x1E);
                 }
                 else

--- a/src/core/mappers/mapper001.h
+++ b/src/core/mappers/mapper001.h
@@ -7,7 +7,7 @@
 #define MAPPER001_NUM_CHR_BANKS_8K  1
 #define MAPPER001_NUM_CHR_BANKS_4K  5
 
-Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart);
+Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -18,7 +18,9 @@ IRAM_ATTR bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 
     Mapper002_state* state = (Mapper002_state*)mapper->state;
     uint8_t bank = data & 0x0F;
-    state->ptr_16K_PRG_banks[0] = getBank(&state->prg_cache, bank, Mapper::ROM_TYPE::PRG_ROM);
+    if (state->backend == ROMBackend::LRU)
+        state->ptr_16K_PRG_banks[0] = getBank(&state->prg_cache, bank, RomType::PRG);
+    else state->ptr_16K_PRG_banks[0] = (uint8_t*)(state->mROM->prg_base + (bank * 16U * 1024U));
     return true;
 }
 
@@ -57,45 +59,83 @@ IRAM_ATTR uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr)
 void mapper002_reset(Mapper* mapper)
 {
     Mapper002_state* state = (Mapper002_state*)mapper->state;
-    state->ptr_16K_PRG_banks[0] = getBank(&state->prg_cache, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_16K_PRG_banks[1] = state->PRG_bank;
+    switch (state->backend)
+    {
+    case ROMBackend::LRU:
+        state->ptr_16K_PRG_banks[0] = getBank(&state->prg_cache, 0, RomType::PRG);
+        state->ptr_16K_PRG_banks[1] = state->PRG_bank;
 
-    state->cart->loadPRGBank(state->ptr_16K_PRG_banks[1], 16U * 1024U,
-                             0x4000 * (state->number_PRG_banks - 1));
-    state->cart->loadCHRBank(state->CHR_bank, 8U * 1024U, 0);
+        state->cart->loadPRGBank(state->ptr_16K_PRG_banks[1], 16U * 1024U,
+                                 0x4000 * (state->number_PRG_banks - 1));
+        state->cart->loadCHRBank(state->CHR_bank, 8U * 1024U, 0);
+        return;
+
+    case ROMBackend::FLASH:
+        state->ptr_16K_PRG_banks[0] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_16K_PRG_banks[1] =
+            (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - (16U * 1024U)));
+
+        if (state->number_CHR_banks != 0) state->CHR_bank = (uint8_t*)state->mROM->chr_base;
+        return;
+    }
 }
 
 void mapper002_dumpState(Mapper* mapper, File& state)
 {
     Mapper002_state* s = (Mapper002_state*)mapper->state;
-
     uint8_t PRG_16K;
-    PRG_16K = getBankIndex(&s->prg_cache, s->ptr_16K_PRG_banks[0]);
-    state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
-    if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, sizeof(s->CHR_bank)); }
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+        PRG_16K = getBankIndex(&s->prg_cache, s->ptr_16K_PRG_banks[0]);
+        state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
+        if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, sizeof(s->CHR_bank)); }
+        return;
+
+    case ROMBackend::FLASH: return;
+    }
 }
 
 void mapper002_loadState(Mapper* mapper, File& state)
 {
     Mapper002_state* s = (Mapper002_state*)mapper->state;
-
     uint8_t PRG_16K;
-    state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
-    invalidateCache(&s->prg_cache);
-    s->ptr_16K_PRG_banks[0] = getBank(&s->prg_cache, PRG_16K, Mapper::ROM_TYPE::PRG_ROM);
-    if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, sizeof(s->CHR_bank)); }
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+        state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
+        invalidateCache(&s->prg_cache);
+        s->ptr_16K_PRG_banks[0] = getBank(&s->prg_cache, PRG_16K, RomType::PRG);
+        if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, sizeof(s->CHR_bank)); }
+        return;
+
+    case ROMBackend::FLASH: return;
+    }
 }
 
-Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart)
+Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
     Mapper002_state* state = new Mapper002_state;
-    bankInit(&state->prg_cache, state->prg_banks, MAPPER002_NUM_PRG_BANKS_16K, 16U * 1024U, cart);
+    switch (backend)
+    {
+    case ROMBackend::LRU:
+        state->PRG_bank = (uint8_t*)malloc(16U * 1024U);
+        state->CHR_bank = (uint8_t*)malloc(8U * 1024U);
+        bankInit(&state->prg_cache, state->prg_banks, MAPPER002_NUM_PRG_BANKS_16K, 16U * 1024U,
+                 cart);
+        break;
 
+    case ROMBackend::FLASH:
+        if (CHR_banks == 0) state->CHR_bank = (uint8_t*)malloc(8U * 1024U);
+        state->mROM = &cart->mROM;
+        break;
+    }
+
+    state->backend = backend;
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;
     state->cart = cart;
-
     mapper.state = state;
     return mapper;
 }

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -1,7 +1,7 @@
 #include "mapper002.h"
 #include "../cartridge.h"
 
-IRAM_ATTR bool mapper002_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper002_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr < 0x8000) return false;
 
@@ -12,7 +12,7 @@ IRAM_ATTR bool mapper002_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr < 0x8000) return false;
 
@@ -24,7 +24,7 @@ IRAM_ATTR bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return true;
 }
 
-IRAM_ATTR bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
 
@@ -33,7 +33,7 @@ IRAM_ATTR bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr > 0x1FFF) return false;
 

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -48,7 +48,7 @@ bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr)
+uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
     if (addr > 0x1FFF) return nullptr;
 

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -92,7 +92,11 @@ void mapper002_dumpState(Mapper* mapper, File& state)
         if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, sizeof(s->CHR_bank)); }
         return;
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        PRG_16K = (s->ptr_16K_PRG_banks[0] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
+        state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
+        if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, sizeof(s->CHR_bank)); }
+        return;
     }
 }
 
@@ -109,7 +113,11 @@ void mapper002_loadState(Mapper* mapper, File& state)
         if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, sizeof(s->CHR_bank)); }
         return;
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
+        s->ptr_16K_PRG_banks[0] = (uint8_t*)(s->mROM->prg_base + (PRG_16K * (16U * 1024U)));
+        if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, sizeof(s->CHR_bank)); }
+        return;
     }
 }
 

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -89,13 +89,13 @@ void mapper002_dumpState(Mapper* mapper, File& state)
     case ROMBackend::LRU:
         PRG_16K = getBankIndex(&s->prg_cache, s->ptr_16K_PRG_banks[0]);
         state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
-        if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, sizeof(s->CHR_bank)); }
+        if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, 8U * 1024U); }
         return;
 
     case ROMBackend::FLASH:
         PRG_16K = (s->ptr_16K_PRG_banks[0] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
         state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
-        if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, sizeof(s->CHR_bank)); }
+        if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, 8U * 1024U); }
         return;
     }
 }
@@ -110,13 +110,13 @@ void mapper002_loadState(Mapper* mapper, File& state)
         state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
         invalidateCache(&s->prg_cache);
         s->ptr_16K_PRG_banks[0] = getBank(&s->prg_cache, PRG_16K, RomType::PRG);
-        if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, sizeof(s->CHR_bank)); }
+        if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, 8U * 1024U); }
         return;
 
     case ROMBackend::FLASH:
         state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
         s->ptr_16K_PRG_banks[0] = (uint8_t*)(s->mROM->prg_base + (PRG_16K * (16U * 1024U)));
-        if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, sizeof(s->CHR_bank)); }
+        if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, 8U * 1024U); }
         return;
     }
 }

--- a/src/core/mappers/mapper002.h
+++ b/src/core/mappers/mapper002.h
@@ -7,16 +7,18 @@
 struct Mapper002_state
 {
     Cartridge* cart;
+    MappedROM* mROM;
+    ROMBackend backend;
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
     uint8_t* ptr_16K_PRG_banks[2];
     Bank prg_banks[MAPPER002_NUM_PRG_BANKS_16K];
     BankCache prg_cache;
-    uint8_t PRG_bank[16U * 1024U];
-    uint8_t CHR_bank[8U * 1024U];
+    uint8_t* PRG_bank;
+    uint8_t* CHR_bank;
 };
 
-Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart);
+Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper002_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -16,7 +16,9 @@ IRAM_ATTR bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 
     Mapper003_state* state = (Mapper003_state*)mapper->state;
     uint8_t bank = data & 0x03;
-    state->ptr_CHR_bank_8K = getBank(&state->CHR_cache_8K, bank, Mapper::ROM_TYPE::CHR_ROM);
+    if (state->backend == ROMBackend::LRU)
+        state->ptr_CHR_bank_8K = getBank(&state->CHR_cache_8K, bank, RomType::CHR);
+    else state->ptr_CHR_bank_8K = (uint8_t*)(state->mROM->chr_base + bank * 8U * 1024U);
     return true;
 }
 
@@ -45,40 +47,68 @@ IRAM_ATTR uint8_t* mapper003_ppuReadPtr(Mapper* mapper, uint16_t addr)
 void mapper003_reset(Mapper* mapper)
 {
     Mapper003_state* state = (Mapper003_state*)mapper->state;
+    switch (state->backend)
+    {
+    case ROMBackend::LRU:
+        state->ptr_CHR_bank_8K = getBank(&state->CHR_cache_8K, 0, RomType::CHR);
+        state->cart->loadPRGBank(state->PRG_bank, 32 * 1024, 0);
+        return;
 
-    state->ptr_CHR_bank_8K = getBank(&state->CHR_cache_8K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->cart->loadPRGBank(state->PRG_bank, 32 * 1024, 0);
+    case ROMBackend::FLASH: return;
+    }
 }
 
 void mapper003_dumpState(Mapper* mapper, File& state)
 {
     Mapper003_state* s = (Mapper003_state*)mapper->state;
-
-    uint8_t CHR_bank = getBankIndex(&s->CHR_cache_8K, s->ptr_CHR_bank_8K);
-    state.write((uint8_t*)&CHR_bank, sizeof(CHR_bank));
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+    {
+        uint8_t CHR_bank = getBankIndex(&s->CHR_cache_8K, s->ptr_CHR_bank_8K);
+        state.write((uint8_t*)&CHR_bank, sizeof(CHR_bank));
+        return;
+    }
+    case ROMBackend::FLASH: return;
+    }
 }
 
 void mapper003_loadState(Mapper* mapper, File& state)
 {
     Mapper003_state* s = (Mapper003_state*)mapper->state;
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+    {
+        uint8_t CHR_bank;
+        state.read((uint8_t*)&CHR_bank, sizeof(CHR_bank));
+        invalidateCache(&s->CHR_cache_8K);
+        s->ptr_CHR_bank_8K = getBank(&s->CHR_cache_8K, CHR_bank, RomType::CHR);
+    }
 
-    uint8_t CHR_bank;
-    state.read((uint8_t*)&CHR_bank, sizeof(CHR_bank));
-    invalidateCache(&s->CHR_cache_8K);
-    s->ptr_CHR_bank_8K = getBank(&s->CHR_cache_8K, CHR_bank, Mapper::ROM_TYPE::PRG_ROM);
+    case ROMBackend::FLASH: return;
+    }
 }
 
-Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart)
+Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
     Mapper003_state* state = new Mapper003_state;
-    bankInit(&state->CHR_cache_8K, state->CHR_banks_8K, MAPPER003_NUM_CHR_BANKS_8K, 8U * 1024U,
-             cart);
+    switch (backend)
+    {
+    case ROMBackend::LRU:
+        state->PRG_bank = (uint8_t*)malloc(32U * 1024U);
+        bankInit(&state->CHR_cache_8K, state->CHR_banks_8K, MAPPER003_NUM_CHR_BANKS_8K, 16U * 1024U,
+                 cart);
+        break;
 
+    case ROMBackend::FLASH: state->mROM = &cart->mROM; break;
+    }
+
+    state->backend = backend;
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;
     state->cart = cart;
-
     mapper.state = state;
     return mapper;
 }

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -88,6 +88,7 @@ void mapper003_loadState(Mapper* mapper, File& state)
         state.read((uint8_t*)&CHR_bank, sizeof(CHR_bank));
         invalidateCache(&s->CHR_cache_8K);
         s->ptr_CHR_bank_8K = getBank(&s->CHR_cache_8K, CHR_bank, RomType::CHR);
+        return;
 
     case ROMBackend::FLASH:
         state.read((uint8_t*)&CHR_bank, sizeof(CHR_bank));

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -1,7 +1,7 @@
 #include "mapper003.h"
 #include "../cartridge.h"
 
-IRAM_ATTR bool mapper003_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper003_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr < 0x8000) return false;
 
@@ -10,7 +10,7 @@ IRAM_ATTR bool mapper003_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr < 0x8000) return false;
 
@@ -22,7 +22,7 @@ IRAM_ATTR bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return true;
 }
 
-IRAM_ATTR bool mapper003_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper003_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
 
@@ -31,7 +31,7 @@ IRAM_ATTR bool mapper003_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper003_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper003_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     return false;
 }

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -54,7 +54,10 @@ void mapper003_reset(Mapper* mapper)
         state->cart->loadPRGBank(state->PRG_bank, 32 * 1024, 0);
         return;
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        state->ptr_CHR_bank_8K = (uint8_t*)state->mROM->chr_base;
+        state->PRG_bank = (uint8_t*)state->mROM->prg_base;
+        return;
     }
 }
 

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -36,7 +36,7 @@ bool mapper003_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR uint8_t* mapper003_ppuReadPtr(Mapper* mapper, uint16_t addr)
+uint8_t* mapper003_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
     if (addr > 0x1FFF) return nullptr;
 
@@ -108,7 +108,9 @@ Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
                  cart);
         break;
 
-    case ROMBackend::FLASH: state->mROM = &cart->mROM; break;
+    case ROMBackend::FLASH:
+        state->mROM = &cart->mROM;
+        break;
     }
 
     state->backend = backend;

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -104,7 +104,7 @@ Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
     {
     case ROMBackend::LRU:
         state->PRG_bank = (uint8_t*)malloc(32U * 1024U);
-        bankInit(&state->CHR_cache_8K, state->CHR_banks_8K, MAPPER003_NUM_CHR_BANKS_8K, 16U * 1024U,
+        bankInit(&state->CHR_cache_8K, state->CHR_banks_8K, MAPPER003_NUM_CHR_BANKS_8K, 8U * 1024U,
                  cart);
         break;
 

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -64,32 +64,35 @@ void mapper003_reset(Mapper* mapper)
 void mapper003_dumpState(Mapper* mapper, File& state)
 {
     Mapper003_state* s = (Mapper003_state*)mapper->state;
+    uint8_t CHR_bank;
     switch (s->backend)
     {
     case ROMBackend::LRU:
-    {
         uint8_t CHR_bank = getBankIndex(&s->CHR_cache_8K, s->ptr_CHR_bank_8K);
         state.write((uint8_t*)&CHR_bank, sizeof(CHR_bank));
         return;
-    }
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        uint8_t CHR_bank = (s->ptr_CHR_bank_8K - (uint8_t*)s->mROM->chr_base) / (8U * 1024U);
+        state.write((uint8_t*)&CHR_bank, sizeof(CHR_bank));
+        return;
     }
 }
 
 void mapper003_loadState(Mapper* mapper, File& state)
 {
     Mapper003_state* s = (Mapper003_state*)mapper->state;
+    uint8_t CHR_bank;
     switch (s->backend)
     {
     case ROMBackend::LRU:
-    {
-        uint8_t CHR_bank;
         state.read((uint8_t*)&CHR_bank, sizeof(CHR_bank));
         invalidateCache(&s->CHR_cache_8K);
         s->ptr_CHR_bank_8K = getBank(&s->CHR_cache_8K, CHR_bank, RomType::CHR);
-    }
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        state.read((uint8_t*)&CHR_bank, sizeof(CHR_bank));
+        s->ptr_CHR_bank_8K = (uint8_t*)(s->mROM->chr_base + CHR_bank * (8U * 1024U));
+        return;
     }
 }
 

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -68,11 +68,11 @@ void mapper003_dumpState(Mapper* mapper, File& state)
     switch (s->backend)
     {
     case ROMBackend::LRU:
-        uint8_t CHR_bank = getBankIndex(&s->CHR_cache_8K, s->ptr_CHR_bank_8K);
+        CHR_bank = getBankIndex(&s->CHR_cache_8K, s->ptr_CHR_bank_8K);
         state.write((uint8_t*)&CHR_bank, sizeof(CHR_bank));
         return;
     case ROMBackend::FLASH:
-        uint8_t CHR_bank = (s->ptr_CHR_bank_8K - (uint8_t*)s->mROM->chr_base) / (8U * 1024U);
+        CHR_bank = (s->ptr_CHR_bank_8K - (uint8_t*)s->mROM->chr_base) / (8U * 1024U);
         state.write((uint8_t*)&CHR_bank, sizeof(CHR_bank));
         return;
     }

--- a/src/core/mappers/mapper003.h
+++ b/src/core/mappers/mapper003.h
@@ -7,16 +7,18 @@
 struct Mapper003_state
 {
     Cartridge* cart;
+    MappedROM* mROM;
+    ROMBackend backend;
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
 
     uint8_t* ptr_CHR_bank_8K;
     Bank CHR_banks_8K[MAPPER003_NUM_CHR_BANKS_8K];
     BankCache CHR_cache_8K;
-    uint8_t PRG_bank[32 * 1024];
+    uint8_t* PRG_bank;
 };
 
-Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart);
+Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper003_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -4,6 +4,8 @@
 struct Mapper004_state
 {
     Cartridge* cart;
+    MappedROM* mROM;
+    ROMBackend backend;
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
     uint8_t* RAM;
@@ -31,6 +33,8 @@ struct Mapper004_state
                                                      Cartridge::MIRROR::HORIZONTAL };
 };
 constexpr Cartridge::MIRROR Mapper004_state::mirror[2];
+static inline uint8_t* getPRGBank(Mapper004_state* state, uint8_t index);
+static inline uint8_t* getCHRBank(Mapper004_state* state, uint8_t index);
 
 IRAM_ATTR bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
@@ -84,61 +88,39 @@ IRAM_ATTR bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
         bank_register[9] = ((state->bank_register[1] & 0xFE) + 1) & state->CHR_mask;
         if (state->CHR_ROM_bank_mode)
         {
-            state->ptr_CHR_bank_1K[0] =
-                getBank(&state->CHR_cache_1K, bank_register[2], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[1] =
-                getBank(&state->CHR_cache_1K, bank_register[3], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[2] =
-                getBank(&state->CHR_cache_1K, bank_register[4], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[3] =
-                getBank(&state->CHR_cache_1K, bank_register[5], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[4] =
-                getBank(&state->CHR_cache_1K, bank_register[0], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[5] =
-                getBank(&state->CHR_cache_1K, bank_register[8], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[6] =
-                getBank(&state->CHR_cache_1K, bank_register[1], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[7] =
-                getBank(&state->CHR_cache_1K, bank_register[9], Mapper::ROM_TYPE::CHR_ROM);
+            state->ptr_CHR_bank_1K[0] = getCHRBank(state, bank_register[2]);
+            state->ptr_CHR_bank_1K[1] = getCHRBank(state, bank_register[3]);
+            state->ptr_CHR_bank_1K[2] = getCHRBank(state, bank_register[4]);
+            state->ptr_CHR_bank_1K[3] = getCHRBank(state, bank_register[5]);
+            state->ptr_CHR_bank_1K[4] = getCHRBank(state, bank_register[0]);
+            state->ptr_CHR_bank_1K[5] = getCHRBank(state, bank_register[8]);
+            state->ptr_CHR_bank_1K[6] = getCHRBank(state, bank_register[1]);
+            state->ptr_CHR_bank_1K[7] = getCHRBank(state, bank_register[9]);
         }
         else
         {
-            state->ptr_CHR_bank_1K[0] =
-                getBank(&state->CHR_cache_1K, bank_register[0], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[1] =
-                getBank(&state->CHR_cache_1K, bank_register[8], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[2] =
-                getBank(&state->CHR_cache_1K, bank_register[1], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[3] =
-                getBank(&state->CHR_cache_1K, bank_register[9], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[4] =
-                getBank(&state->CHR_cache_1K, bank_register[2], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[5] =
-                getBank(&state->CHR_cache_1K, bank_register[3], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[6] =
-                getBank(&state->CHR_cache_1K, bank_register[4], Mapper::ROM_TYPE::CHR_ROM);
-            state->ptr_CHR_bank_1K[7] =
-                getBank(&state->CHR_cache_1K, bank_register[5], Mapper::ROM_TYPE::CHR_ROM);
+            state->ptr_CHR_bank_1K[0] = getCHRBank(state, bank_register[0]);
+            state->ptr_CHR_bank_1K[1] = getCHRBank(state, bank_register[8]);
+            state->ptr_CHR_bank_1K[2] = getCHRBank(state, bank_register[1]);
+            state->ptr_CHR_bank_1K[3] = getCHRBank(state, bank_register[9]);
+            state->ptr_CHR_bank_1K[4] = getCHRBank(state, bank_register[2]);
+            state->ptr_CHR_bank_1K[5] = getCHRBank(state, bank_register[3]);
+            state->ptr_CHR_bank_1K[6] = getCHRBank(state, bank_register[4]);
+            state->ptr_CHR_bank_1K[7] = getCHRBank(state, bank_register[5]);
         }
 
         if (state->PRG_ROM_bank_mode)
         {
-            state->ptr_PRG_bank_8K[0] = getBank(
-                &state->PRG_cache_8K, (state->number_PRG_banks * 2) - 2, Mapper::ROM_TYPE::PRG_ROM);
-            state->ptr_PRG_bank_8K[2] =
-                getBank(&state->PRG_cache_8K, bank_register[6], Mapper::ROM_TYPE::PRG_ROM);
+            state->ptr_PRG_bank_8K[0] = getPRGBank(state, (state->number_PRG_banks * 2) - 2);
+            state->ptr_PRG_bank_8K[2] = getPRGBank(state, bank_register[6]);
         }
         else
         {
-            state->ptr_PRG_bank_8K[0] =
-                getBank(&state->PRG_cache_8K, bank_register[6], Mapper::ROM_TYPE::PRG_ROM);
-            state->ptr_PRG_bank_8K[2] = getBank(
-                &state->PRG_cache_8K, (state->number_PRG_banks * 2) - 2, Mapper::ROM_TYPE::PRG_ROM);
+            state->ptr_PRG_bank_8K[0] = getPRGBank(state, bank_register[6]);
+            state->ptr_PRG_bank_8K[2] = getPRGBank(state, (state->number_PRG_banks * 2) - 2);
         }
-        state->ptr_PRG_bank_8K[1] =
-            getBank(&state->PRG_cache_8K, bank_register[7], Mapper::ROM_TYPE::PRG_ROM);
-        state->ptr_PRG_bank_8K[3] = getBank(&state->PRG_cache_8K, (state->number_PRG_banks * 2) - 1,
-                                            Mapper::ROM_TYPE::PRG_ROM);
+        state->ptr_PRG_bank_8K[1] = getPRGBank(state, bank_register[7]);
+        state->ptr_PRG_bank_8K[3] = getPRGBank(state, (state->number_PRG_banks * 2) - 1);
         break;
 
     // Mirroring (even address)
@@ -197,21 +179,45 @@ void mapper004_reset(Mapper* mapper)
 {
     Mapper004_state* state = (Mapper004_state*)mapper->state;
     memset(state->RAM, 0, 8U * 1024U);
-    state->ptr_PRG_bank_8K[0] = getBank(&state->PRG_cache_8K, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_PRG_bank_8K[1] = getBank(&state->PRG_cache_8K, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_PRG_bank_8K[2] =
-        getBank(&state->PRG_cache_8K, (state->number_PRG_banks * 2) - 2, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_PRG_bank_8K[3] =
-        getBank(&state->PRG_cache_8K, (state->number_PRG_banks * 2) - 1, Mapper::ROM_TYPE::PRG_ROM);
 
-    state->ptr_CHR_bank_1K[0] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[1] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[2] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[3] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[4] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[5] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[6] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[7] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
+    switch (state->backend)
+    {
+    case ROMBackend::LRU:
+        state->ptr_PRG_bank_8K[0] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+        state->ptr_PRG_bank_8K[1] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+        state->ptr_PRG_bank_8K[2] =
+            getBank(&state->PRG_cache_8K, (state->number_PRG_banks * 2) - 2, RomType::PRG);
+        state->ptr_PRG_bank_8K[3] =
+            getBank(&state->PRG_cache_8K, (state->number_PRG_banks * 2) - 1, RomType::PRG);
+
+        state->ptr_CHR_bank_1K[0] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[1] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[2] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[3] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[4] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[5] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[6] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[7] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        break;
+
+    case ROMBackend::FLASH:
+        state->ptr_PRG_bank_8K[0] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_8K[1] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_8K[2] =
+            (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - ((8U * 1024U) * 2)));
+        state->ptr_PRG_bank_8K[3] =
+            (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - ((8U * 1024U) * 1)));
+
+        state->ptr_CHR_bank_1K[0] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[1] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[2] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[3] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[4] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[5] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[6] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[7] = (uint8_t*)state->mROM->chr_base;
+        break;
+    }
 
     state->bank_select = 0x00;
     state->IRQ_latch = 0x00;
@@ -227,73 +233,113 @@ void mapper004_reset(Mapper* mapper)
 void mapper004_dumpState(Mapper* mapper, File& state)
 {
     Mapper004_state* s = (Mapper004_state*)mapper->state;
-    state.write(s->bank_register, sizeof(s->bank_register));
-    state.write((uint8_t*)&s->bank_select, sizeof(s->bank_select));
-    state.write((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
-    state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-    state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-    state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-    state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+    {
+        state.write(s->bank_register, sizeof(s->bank_register));
+        state.write((uint8_t*)&s->bank_select, sizeof(s->bank_select));
+        state.write((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
+        state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+        state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+        state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+        state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
 
-    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
-    state.write((uint8_t*)&mirror, sizeof(mirror));
+        Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+        state.write((uint8_t*)&mirror, sizeof(mirror));
 
-    uint8_t PRG_bank_8K[4];
-    uint8_t CHR_bank_1K[8];
-    for (int i = 0; i < 4; i++)
-        PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
-    for (int i = 0; i < 8; i++)
-        CHR_bank_1K[i] = getBankIndex(&s->CHR_cache_1K, s->ptr_CHR_bank_1K[i]);
-    state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
-    state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
-    state.write(s->RAM, 8U * 1024U);
+        uint8_t PRG_bank_8K[4];
+        uint8_t CHR_bank_1K[8];
+        for (int i = 0; i < 4; i++)
+            PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
+        for (int i = 0; i < 8; i++)
+            CHR_bank_1K[i] = getBankIndex(&s->CHR_cache_1K, s->ptr_CHR_bank_1K[i]);
+        state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
+        state.write(s->RAM, 8U * 1024U);
+        return;
+    }
+
+    case ROMBackend::FLASH: return;
+    }
 }
 
 void mapper004_loadState(Mapper* mapper, File& state)
 {
     Mapper004_state* s = (Mapper004_state*)mapper->state;
-    state.read(s->bank_register, sizeof(s->bank_register));
-    state.read((uint8_t*)&s->bank_select, sizeof(s->bank_select));
-    state.read((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
-    state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-    state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-    state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-    state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+    {
+        state.read(s->bank_register, sizeof(s->bank_register));
+        state.read((uint8_t*)&s->bank_select, sizeof(s->bank_select));
+        state.read((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
+        state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+        state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+        state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+        state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
 
-    Cartridge::MIRROR mirror;
-    state.read((uint8_t*)&mirror, sizeof(mirror));
-    s->cart->setMirrorMode(mirror);
+        Cartridge::MIRROR mirror;
+        state.read((uint8_t*)&mirror, sizeof(mirror));
+        s->cart->setMirrorMode(mirror);
 
-    uint8_t PRG_bank_8K[4];
-    uint8_t CHR_bank_1K[8];
-    state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
-    state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
+        uint8_t PRG_bank_8K[4];
+        uint8_t CHR_bank_1K[8];
+        state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
 
-    invalidateCache(&s->PRG_cache_8K);
-    invalidateCache(&s->CHR_cache_1K);
-    for (int i = 0; i < 4; i++)
-        s->ptr_PRG_bank_8K[i] =
-            getBank(&s->PRG_cache_8K, PRG_bank_8K[i], Mapper::ROM_TYPE::PRG_ROM);
-    for (int i = 0; i < 8; i++)
-        s->ptr_CHR_bank_1K[i] =
-            getBank(&s->CHR_cache_1K, CHR_bank_1K[i], Mapper::ROM_TYPE::CHR_ROM);
+        invalidateCache(&s->PRG_cache_8K);
+        invalidateCache(&s->CHR_cache_1K);
+        for (int i = 0; i < 4; i++)
+            s->ptr_PRG_bank_8K[i] = getBank(&s->PRG_cache_8K, PRG_bank_8K[i], RomType::PRG);
+        for (int i = 0; i < 8; i++)
+            s->ptr_CHR_bank_1K[i] = getBank(&s->CHR_cache_1K, CHR_bank_1K[i], RomType::CHR);
 
-    state.read(s->RAM, 8U * 1024U);
+        state.read(s->RAM, 8U * 1024U);
+        return;
+    }
+
+    case ROMBackend::FLASH: return;
+    }
 }
 
-Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart)
+Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
     Mapper004_state* state = new Mapper004_state;
+
+    state->RAM = (uint8_t*)malloc(8U * 1024U);
+    switch (backend)
+    {
+    case ROMBackend::LRU:
+        bankInit(&state->PRG_cache_8K, state->PRG_banks_8K, MAPPER004_NUM_PRG_BANKS_8K, 8U * 1024U,
+                 cart);
+        bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER004_NUM_CHR_BANKS_1K, 1 * 1024,
+                 cart);
+        break;
+
+    case ROMBackend::FLASH: state->mROM = &cart->mROM; break;
+    }
+
+    state->backend = backend;
     state->number_PRG_banks = PRG_banks;
     state->number_CHR_banks = CHR_banks;
     state->cart = cart;
-
-    bankInit(&state->PRG_cache_8K, state->PRG_banks_8K, MAPPER004_NUM_PRG_BANKS_8K, 8U * 1024U,
-             cart);
-    bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER004_NUM_CHR_BANKS_1K, 1 * 1024, cart);
-    state->RAM = (uint8_t*)malloc(8U * 1024U);
-
     mapper.state = state;
     return mapper;
+}
+
+// Helper functions
+static inline uint8_t* getPRGBank(Mapper004_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->PRG_cache_8K, index, RomType::PRG);
+    return (uint8_t*)(state->mROM->prg_base + (uint32_t)index * 8U * 1024U);
+}
+
+static inline uint8_t* getCHRBank(Mapper004_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->CHR_cache_1K, index, RomType::CHR);
+    return (uint8_t*)(state->mROM->chr_base + (uint32_t)index * 1U * 1024U);
 }

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -155,7 +155,7 @@ bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr)
+uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
     if (addr > 0x1FFF) return nullptr;
 
@@ -164,7 +164,7 @@ IRAM_ATTR uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr)
     return &state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
 }
 
-IRAM_ATTR void mapper004_scanline(Mapper* mapper)
+void mapper004_scanline(Mapper* mapper)
 {
     Mapper004_state* state = (Mapper004_state*)mapper->state;
     if (state->IRQ_counter == 0) state->IRQ_counter = state->IRQ_latch;

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -233,23 +233,23 @@ void mapper004_reset(Mapper* mapper)
 void mapper004_dumpState(Mapper* mapper, File& state)
 {
     Mapper004_state* s = (Mapper004_state*)mapper->state;
+    state.write(s->bank_register, sizeof(s->bank_register));
+    state.write((uint8_t*)&s->bank_select, sizeof(s->bank_select));
+    state.write((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
+    state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+    state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+    state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+    state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+
+    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+    state.write((uint8_t*)&mirror, sizeof(mirror));
+
+    uint8_t PRG_bank_8K[4];
+    uint8_t CHR_bank_1K[8];
     switch (s->backend)
     {
     case ROMBackend::LRU:
     {
-        state.write(s->bank_register, sizeof(s->bank_register));
-        state.write((uint8_t*)&s->bank_select, sizeof(s->bank_select));
-        state.write((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
-        state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-        state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-        state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-        state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-
-        Cartridge::MIRROR mirror = s->cart->getMirrorMode();
-        state.write((uint8_t*)&mirror, sizeof(mirror));
-
-        uint8_t PRG_bank_8K[4];
-        uint8_t CHR_bank_1K[8];
         for (int i = 0; i < 4; i++)
             PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
         for (int i = 0; i < 8; i++)
@@ -260,31 +260,38 @@ void mapper004_dumpState(Mapper* mapper, File& state)
         return;
     }
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        for (int i = 0; i < 4; i++)
+            PRG_bank_8K[i] = (s->ptr_PRG_bank_8K[i] - (uint8_t*)s->mROM->prg_base) / (8U * 1024U);
+        for (int i = 0; i < 8; i++)
+            CHR_bank_1K[i] = (s->ptr_CHR_bank_1K[i] - (uint8_t*)s->mROM->chr_base) / (1U * 1024U);
+        state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
+        state.write(s->RAM, 8U * 1024U);
+        return;
     }
 }
 
 void mapper004_loadState(Mapper* mapper, File& state)
 {
     Mapper004_state* s = (Mapper004_state*)mapper->state;
+    state.read(s->bank_register, sizeof(s->bank_register));
+    state.read((uint8_t*)&s->bank_select, sizeof(s->bank_select));
+    state.read((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
+    state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+    state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+    state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
+    state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
+    Cartridge::MIRROR mirror;
+    state.read((uint8_t*)&mirror, sizeof(mirror));
+    s->cart->setMirrorMode(mirror);
+
+    uint8_t PRG_bank_8K[4];
+    uint8_t CHR_bank_1K[8];
     switch (s->backend)
     {
     case ROMBackend::LRU:
     {
-        state.read(s->bank_register, sizeof(s->bank_register));
-        state.read((uint8_t*)&s->bank_select, sizeof(s->bank_select));
-        state.read((uint8_t*)&s->IRQ_latch, sizeof(s->IRQ_latch));
-        state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-        state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-        state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
-        state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-
-        Cartridge::MIRROR mirror;
-        state.read((uint8_t*)&mirror, sizeof(mirror));
-        s->cart->setMirrorMode(mirror);
-
-        uint8_t PRG_bank_8K[4];
-        uint8_t CHR_bank_1K[8];
         state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
         state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
 
@@ -299,7 +306,16 @@ void mapper004_loadState(Mapper* mapper, File& state)
         return;
     }
 
-    case ROMBackend::FLASH: return;
+    case ROMBackend::FLASH:
+        state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
+        for (int i = 0; i < 4; i++)
+            s->ptr_PRG_bank_8K[i] = (uint8_t*)(s->mROM->prg_base + (PRG_bank_8K[i] * (8U * 1024U)));
+        for (int i = 0; i < 8; i++)
+            s->ptr_CHR_bank_1K[i] = (uint8_t*)(s->mROM->chr_base + (CHR_bank_1K[i] * (1U * 1024U)));
+
+        state.read(s->RAM, 8U * 1024U);
+        return;
     }
 }
 

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -36,7 +36,7 @@ constexpr Cartridge::MIRROR Mapper004_state::mirror[2];
 static inline uint8_t* getPRGBank(Mapper004_state* state, uint8_t index);
 static inline uint8_t* getCHRBank(Mapper004_state* state, uint8_t index);
 
-IRAM_ATTR bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr < 0x6000) return false;
 
@@ -52,7 +52,7 @@ IRAM_ATTR bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr < 0x6000) return false;
 
@@ -140,7 +140,7 @@ IRAM_ATTR bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
 
@@ -150,7 +150,7 @@ IRAM_ATTR bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     return false;
 }

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -330,7 +330,7 @@ Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
     case ROMBackend::LRU:
         bankInit(&state->PRG_cache_8K, state->PRG_banks_8K, MAPPER004_NUM_PRG_BANKS_8K, 8U * 1024U,
                  cart);
-        bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER004_NUM_CHR_BANKS_1K, 1 * 1024,
+        bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER004_NUM_CHR_BANKS_1K, 1U * 1024,
                  cart);
         break;
 

--- a/src/core/mappers/mapper004.h
+++ b/src/core/mappers/mapper004.h
@@ -6,7 +6,7 @@
 #define MAPPER004_NUM_PRG_BANKS_8K 18
 #define MAPPER004_NUM_CHR_BANKS_1K 26
 
-Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart);
+Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);

--- a/src/core/mappers/mapper004.h
+++ b/src/core/mappers/mapper004.h
@@ -4,7 +4,7 @@
 #include "../mapper.h"
 
 #define MAPPER004_NUM_PRG_BANKS_8K 18
-#define MAPPER004_NUM_CHR_BANKS_1K 26
+#define MAPPER004_NUM_CHR_BANKS_1K 24
 
 Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -238,7 +238,7 @@ void mapper069_loadState(Mapper* mapper, File& state)
     state.read(s->RAM, 8U * 1024U);
 }
 
-Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart)
+Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
     Mapper069_state* state = new Mapper069_state;

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -86,12 +86,12 @@ IRAM_ATTR bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
         case 0x06:
         case 0x07:
             state->ptr_CHR_bank_1K[command] =
-                getBank(&state->CHR_cache_1K, data & state->CHR_mask, Mapper::ROM_TYPE::CHR_ROM);
+                getBank(&state->CHR_cache_1K, data & state->CHR_mask, RomType::CHR);
             break;
 
         case 0x08:
-            state->ptr_PRG_bank_8K[command & 0x03] = getBank(
-                &state->PRG_cache_8K, (data & 0x3F) & state->PRG_mask, Mapper::ROM_TYPE::PRG_ROM);
+            state->ptr_PRG_bank_8K[command & 0x03] =
+                getBank(&state->PRG_cache_8K, (data & 0x3F) & state->PRG_mask, RomType::PRG);
             state->PRG_RAM_select = (data & 0x40) != 0;
             state->PRG_RAM_enable = (data & 0x80) != 0;
             break;
@@ -99,8 +99,8 @@ IRAM_ATTR bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
         case 0x09:
         case 0x0A:
         case 0x0B:
-            state->ptr_PRG_bank_8K[command & 0x03] = getBank(
-                &state->PRG_cache_8K, (data & 0x3F) & state->PRG_mask, Mapper::ROM_TYPE::PRG_ROM);
+            state->ptr_PRG_bank_8K[command & 0x03] =
+                getBank(&state->PRG_cache_8K, (data & 0x3F) & state->PRG_mask, RomType::PRG);
             break;
 
         case 0x0C: state->cart->setMirrorMode(state->mirror[data & 0x03]); break;
@@ -155,21 +155,21 @@ void mapper069_reset(Mapper* mapper)
 {
     Mapper069_state* state = (Mapper069_state*)mapper->state;
     memset(state->RAM, 0, 8U * 1024U);
-    state->ptr_PRG_bank_8K[0] = getBank(&state->PRG_cache_8K, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_PRG_bank_8K[1] = getBank(&state->PRG_cache_8K, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_PRG_bank_8K[2] = getBank(&state->PRG_cache_8K, 0, Mapper::ROM_TYPE::PRG_ROM);
-    state->ptr_PRG_bank_8K[3] = getBank(&state->PRG_cache_8K, 0, Mapper::ROM_TYPE::PRG_ROM);
+    state->ptr_PRG_bank_8K[0] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+    state->ptr_PRG_bank_8K[1] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+    state->ptr_PRG_bank_8K[2] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+    state->ptr_PRG_bank_8K[3] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
     state->cart->loadPRGBank(state->ptr_PRG_bank_8K[4], 8U * 1024U,
                              ((state->number_PRG_banks * 2) - 1) * 8U * 1024U);
 
-    state->ptr_CHR_bank_1K[0] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[1] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[2] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[3] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[4] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[5] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[6] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
-    state->ptr_CHR_bank_1K[7] = getBank(&state->CHR_cache_1K, 0, Mapper::ROM_TYPE::CHR_ROM);
+    state->ptr_CHR_bank_1K[0] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[1] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[2] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[3] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[4] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[5] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[6] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+    state->ptr_CHR_bank_1K[7] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
 
     state->command_register = 0x00;
     state->parameter_register = 0x00;
@@ -231,11 +231,9 @@ void mapper069_loadState(Mapper* mapper, File& state)
     invalidateCache(&s->PRG_cache_8K);
     invalidateCache(&s->CHR_cache_1K);
     for (int i = 0; i < 4; i++)
-        s->ptr_PRG_bank_8K[i] =
-            getBank(&s->PRG_cache_8K, PRG_bank_8K[i], Mapper::ROM_TYPE::PRG_ROM);
+        s->ptr_PRG_bank_8K[i] = getBank(&s->PRG_cache_8K, PRG_bank_8K[i], RomType::PRG);
     for (int i = 0; i < 8; i++)
-        s->ptr_CHR_bank_1K[i] =
-            getBank(&s->CHR_cache_1K, CHR_bank_1K[i], Mapper::ROM_TYPE::CHR_ROM);
+        s->ptr_CHR_bank_1K[i] = getBank(&s->CHR_cache_1K, CHR_bank_1K[i], RomType::CHR);
 
     state.read(s->RAM, 8U * 1024U);
 }

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -4,6 +4,8 @@
 struct Mapper069_state
 {
     Cartridge* cart;
+    MappedROM* mROM;
+    ROMBackend backend;
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
     uint8_t* RAM;
@@ -33,6 +35,8 @@ struct Mapper069_state
                                                      Cartridge::MIRROR::ONESCREEN_HIGH };
 };
 constexpr Cartridge::MIRROR Mapper069_state::mirror[4];
+static inline uint8_t* getPRGBank(Mapper069_state* state, uint8_t index);
+static inline uint8_t* getCHRBank(Mapper069_state* state, uint8_t index);
 
 IRAM_ATTR bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
@@ -85,13 +89,12 @@ IRAM_ATTR bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
         case 0x05:
         case 0x06:
         case 0x07:
-            state->ptr_CHR_bank_1K[command] =
-                getBank(&state->CHR_cache_1K, data & state->CHR_mask, RomType::CHR);
+            state->ptr_CHR_bank_1K[command] = getCHRBank(state, data & state->CHR_mask);
             break;
 
         case 0x08:
             state->ptr_PRG_bank_8K[command & 0x03] =
-                getBank(&state->PRG_cache_8K, (data & 0x3F) & state->PRG_mask, RomType::PRG);
+                getPRGBank(state, (data & 0x3F) & state->PRG_mask);
             state->PRG_RAM_select = (data & 0x40) != 0;
             state->PRG_RAM_enable = (data & 0x80) != 0;
             break;
@@ -100,7 +103,7 @@ IRAM_ATTR bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
         case 0x0A:
         case 0x0B:
             state->ptr_PRG_bank_8K[command & 0x03] =
-                getBank(&state->PRG_cache_8K, (data & 0x3F) & state->PRG_mask, RomType::PRG);
+                getPRGBank(state, (data & 0x3F) & state->PRG_mask);
             break;
 
         case 0x0C: state->cart->setMirrorMode(state->mirror[data & 0x03]); break;
@@ -154,22 +157,44 @@ IRAM_ATTR void mapper069_cycle(Mapper* mapper, int cycles)
 void mapper069_reset(Mapper* mapper)
 {
     Mapper069_state* state = (Mapper069_state*)mapper->state;
-    memset(state->RAM, 0, 8U * 1024U);
-    state->ptr_PRG_bank_8K[0] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
-    state->ptr_PRG_bank_8K[1] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
-    state->ptr_PRG_bank_8K[2] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
-    state->ptr_PRG_bank_8K[3] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
-    state->cart->loadPRGBank(state->ptr_PRG_bank_8K[4], 8U * 1024U,
-                             ((state->number_PRG_banks * 2) - 1) * 8U * 1024U);
+    if (state->RAM) memset(state->RAM, 0, 16U * 1024U);
+    switch (state->backend)
+    {
+    case ROMBackend::LRU:
+        state->ptr_PRG_bank_8K[0] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+        state->ptr_PRG_bank_8K[1] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+        state->ptr_PRG_bank_8K[2] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+        state->ptr_PRG_bank_8K[3] = getBank(&state->PRG_cache_8K, 0, RomType::PRG);
+        state->cart->loadPRGBank(state->ptr_PRG_bank_8K[4], 8U * 1024U,
+                                 ((state->number_PRG_banks * 2) - 1) * 8U * 1024U);
 
-    state->ptr_CHR_bank_1K[0] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[1] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[2] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[3] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[4] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[5] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[6] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
-    state->ptr_CHR_bank_1K[7] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[0] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[1] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[2] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[3] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[4] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[5] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[6] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        state->ptr_CHR_bank_1K[7] = getBank(&state->CHR_cache_1K, 0, RomType::CHR);
+        break;
+
+    case ROMBackend::FLASH:
+        state->ptr_PRG_bank_8K[0] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_8K[1] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_8K[2] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_8K[3] =
+            (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - (8U * 1024U)));
+
+        state->ptr_CHR_bank_1K[0] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[1] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[2] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[3] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[4] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[5] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[6] = (uint8_t*)state->mROM->chr_base;
+        state->ptr_CHR_bank_1K[7] = (uint8_t*)state->mROM->chr_base;
+        break;
+    }
 
     state->command_register = 0x00;
     state->parameter_register = 0x00;
@@ -186,72 +211,113 @@ void mapper069_reset(Mapper* mapper)
 void mapper069_dumpState(Mapper* mapper, File& state)
 {
     Mapper069_state* s = (Mapper069_state*)mapper->state;
-    state.write((uint8_t*)&s->command_register, sizeof(s->command_register));
-    state.write((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
-    state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-    state.write((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
-    state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-    state.write((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
-    state.write((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+    {
+        state.write((uint8_t*)&s->command_register, sizeof(s->command_register));
+        state.write((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
+        state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+        state.write((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
+        state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+        state.write((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
+        state.write((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
 
-    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
-    state.write((uint8_t*)&mirror, sizeof(mirror));
+        Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+        state.write((uint8_t*)&mirror, sizeof(mirror));
 
-    uint8_t PRG_bank_8K[4];
-    uint8_t CHR_bank_1K[8];
-    for (int i = 0; i < 4; i++)
-        PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
-    for (int i = 0; i < 8; i++)
-        CHR_bank_1K[i] = getBankIndex(&s->CHR_cache_1K, s->ptr_CHR_bank_1K[i]);
-    state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
-    state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
-    state.write(s->RAM, 8U * 1024U);
+        uint8_t PRG_bank_8K[4];
+        uint8_t CHR_bank_1K[8];
+        for (int i = 0; i < 4; i++)
+            PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
+        for (int i = 0; i < 8; i++)
+            CHR_bank_1K[i] = getBankIndex(&s->CHR_cache_1K, s->ptr_CHR_bank_1K[i]);
+        state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
+        state.write(s->RAM, 8U * 1024U);
+        break;
+    }
+
+    case ROMBackend::FLASH: break;
+    }
 }
 
 void mapper069_loadState(Mapper* mapper, File& state)
 {
     Mapper069_state* s = (Mapper069_state*)mapper->state;
-    state.read((uint8_t*)&s->command_register, sizeof(s->command_register));
-    state.read((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
-    state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-    state.read((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
-    state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-    state.read((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
-    state.read((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
+    switch (s->backend)
+    {
+    case ROMBackend::LRU:
+        state.read((uint8_t*)&s->command_register, sizeof(s->command_register));
+        state.read((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
+        state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+        state.read((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
+        state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+        state.read((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
+        state.read((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
 
-    Cartridge::MIRROR mirror;
-    state.read((uint8_t*)&mirror, sizeof(mirror));
-    s->cart->setMirrorMode(mirror);
+        Cartridge::MIRROR mirror;
+        state.read((uint8_t*)&mirror, sizeof(mirror));
+        s->cart->setMirrorMode(mirror);
 
-    uint8_t PRG_bank_8K[4];
-    uint8_t CHR_bank_1K[8];
-    state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
-    state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
+        uint8_t PRG_bank_8K[4];
+        uint8_t CHR_bank_1K[8];
+        state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
 
-    invalidateCache(&s->PRG_cache_8K);
-    invalidateCache(&s->CHR_cache_1K);
-    for (int i = 0; i < 4; i++)
-        s->ptr_PRG_bank_8K[i] = getBank(&s->PRG_cache_8K, PRG_bank_8K[i], RomType::PRG);
-    for (int i = 0; i < 8; i++)
-        s->ptr_CHR_bank_1K[i] = getBank(&s->CHR_cache_1K, CHR_bank_1K[i], RomType::CHR);
+        invalidateCache(&s->PRG_cache_8K);
+        invalidateCache(&s->CHR_cache_1K);
+        for (int i = 0; i < 4; i++)
+            s->ptr_PRG_bank_8K[i] = getBank(&s->PRG_cache_8K, PRG_bank_8K[i], RomType::PRG);
+        for (int i = 0; i < 8; i++)
+            s->ptr_CHR_bank_1K[i] = getBank(&s->CHR_cache_1K, CHR_bank_1K[i], RomType::CHR);
 
-    state.read(s->RAM, 8U * 1024U);
+        state.read(s->RAM, 8U * 1024U);
+        break;
+
+    case ROMBackend::FLASH: break;
+    }
 }
 
 Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart)
 {
     Mapper mapper;
     Mapper069_state* state = new Mapper069_state;
-    state->number_PRG_banks = PRG_banks;
-    state->number_CHR_banks = CHR_banks;
-    state->cart = cart;
 
-    bankInit(&state->PRG_cache_8K, state->PRG_banks_8K, MAPPER069_NUM_PRG_BANKS_8K, 8U * 1024U,
-             cart);
-    bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER069_NUM_CHR_BANKS_1K, 1 * 1024, cart);
     state->RAM = (uint8_t*)malloc(8U * 1024U);
     state->ptr_PRG_bank_8K[4] = (uint8_t*)malloc(8U * 1024U);
 
+    switch (backend)
+    {
+    case ROMBackend::LRU:
+        bankInit(&state->PRG_cache_8K, state->PRG_banks_8K, MAPPER069_NUM_PRG_BANKS_8K, 8U * 1024U,
+                 cart);
+        bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER069_NUM_CHR_BANKS_1K, 1 * 1024,
+                 cart);
+        break;
+
+    case ROMBackend::FLASH: break;
+    }
+
+    state->number_PRG_banks = PRG_banks;
+    state->number_CHR_banks = CHR_banks;
+    state->backend = backend;
+    state->cart = cart;
     mapper.state = state;
     return mapper;
+}
+
+// Helper functions
+static inline uint8_t* getPRGBank(Mapper069_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->PRG_cache_8K, index, RomType::PRG);
+    return (uint8_t*)(state->mROM->prg_base + (uint32_t)index * 8U * 1024U);
+}
+
+static inline uint8_t* getCHRBank(Mapper069_state* state, uint8_t index)
+{
+    if (state->backend == ROMBackend::LRU)
+        return getBank(&state->CHR_cache_1K, index, RomType::CHR);
+    return (uint8_t*)(state->mROM->chr_base + (uint32_t)index * 1U * 1024U);
 }

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -211,23 +211,23 @@ void mapper069_reset(Mapper* mapper)
 void mapper069_dumpState(Mapper* mapper, File& state)
 {
     Mapper069_state* s = (Mapper069_state*)mapper->state;
+    state.write((uint8_t*)&s->command_register, sizeof(s->command_register));
+    state.write((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
+    state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+    state.write((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
+    state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+    state.write((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
+    state.write((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
+
+    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+    state.write((uint8_t*)&mirror, sizeof(mirror));
+
+    uint8_t PRG_bank_8K[4];
+    uint8_t CHR_bank_1K[8];
     switch (s->backend)
     {
     case ROMBackend::LRU:
     {
-        state.write((uint8_t*)&s->command_register, sizeof(s->command_register));
-        state.write((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
-        state.write((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-        state.write((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
-        state.write((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-        state.write((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
-        state.write((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
-
-        Cartridge::MIRROR mirror = s->cart->getMirrorMode();
-        state.write((uint8_t*)&mirror, sizeof(mirror));
-
-        uint8_t PRG_bank_8K[4];
-        uint8_t CHR_bank_1K[8];
         for (int i = 0; i < 4; i++)
             PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
         for (int i = 0; i < 8; i++)
@@ -235,33 +235,41 @@ void mapper069_dumpState(Mapper* mapper, File& state)
         state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
         state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
         state.write(s->RAM, 8U * 1024U);
-        break;
+        return;
     }
 
-    case ROMBackend::FLASH: break;
+    case ROMBackend::FLASH:
+        for (int i = 0; i < 4; i++)
+            PRG_bank_8K[i] = (s->ptr_PRG_bank_8K[i] - (uint8_t*)s->mROM->prg_base) / (8U * 1024U);
+        for (int i = 0; i < 8; i++)
+            CHR_bank_1K[i] = (s->ptr_CHR_bank_1K[i] - (uint8_t*)s->mROM->chr_base) / (1U * 1024U);
+        state.write(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
+        state.write(s->RAM, 8U * 1024U);
+        return;
     }
 }
 
 void mapper069_loadState(Mapper* mapper, File& state)
 {
     Mapper069_state* s = (Mapper069_state*)mapper->state;
+    state.read((uint8_t*)&s->command_register, sizeof(s->command_register));
+    state.read((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
+    state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
+    state.read((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
+    state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
+    state.read((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
+    state.read((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
+
+    Cartridge::MIRROR mirror;
+    state.read((uint8_t*)&mirror, sizeof(mirror));
+    s->cart->setMirrorMode(mirror);
+
+    uint8_t PRG_bank_8K[4];
+    uint8_t CHR_bank_1K[8];
     switch (s->backend)
     {
     case ROMBackend::LRU:
-        state.read((uint8_t*)&s->command_register, sizeof(s->command_register));
-        state.read((uint8_t*)&s->parameter_register, sizeof(s->parameter_register));
-        state.read((uint8_t*)&s->IRQ_counter, sizeof(s->IRQ_counter));
-        state.read((uint8_t*)&s->IRQ_counter_enable, sizeof(s->IRQ_counter_enable));
-        state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
-        state.read((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
-        state.read((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
-
-        Cartridge::MIRROR mirror;
-        state.read((uint8_t*)&mirror, sizeof(mirror));
-        s->cart->setMirrorMode(mirror);
-
-        uint8_t PRG_bank_8K[4];
-        uint8_t CHR_bank_1K[8];
         state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
         state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
 
@@ -273,9 +281,17 @@ void mapper069_loadState(Mapper* mapper, File& state)
             s->ptr_CHR_bank_1K[i] = getBank(&s->CHR_cache_1K, CHR_bank_1K[i], RomType::CHR);
 
         state.read(s->RAM, 8U * 1024U);
-        break;
+        return;
 
-    case ROMBackend::FLASH: break;
+    case ROMBackend::FLASH:
+        state.read(PRG_bank_8K, sizeof(PRG_bank_8K));
+        state.read(CHR_bank_1K, sizeof(CHR_bank_1K));
+
+        for (int i = 0; i < 4; i++)
+            s->ptr_PRG_bank_8K[i] = (uint8_t*)(s->mROM->prg_base + (PRG_bank_8K[i] * (8U * 1024U)));
+        for (int i = 0; i < 8; i++)
+            s->ptr_CHR_bank_1K[i] = (uint8_t*)(s->mROM->chr_base + (CHR_bank_1K[i] * (1U * 1024U)));
+        return;
     }
 }
 

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -134,7 +134,7 @@ bool mapper069_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR uint8_t* mapper069_ppuReadPtr(Mapper* mapper, uint16_t addr)
+uint8_t* mapper069_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
     if (addr > 0x1FFF) return nullptr;
 
@@ -143,7 +143,7 @@ IRAM_ATTR uint8_t* mapper069_ppuReadPtr(Mapper* mapper, uint16_t addr)
     return &state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
 }
 
-IRAM_ATTR void mapper069_cycle(Mapper* mapper, int cycles)
+void mapper069_cycle(Mapper* mapper, int cycles)
 {
     Mapper069_state* state = (Mapper069_state*)mapper->state;
     if (!state->IRQ_counter_enable) return;
@@ -312,7 +312,9 @@ Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
                  cart);
         break;
 
-    case ROMBackend::FLASH: break;
+    case ROMBackend::FLASH:
+        state->mROM = &cart->mROM;
+        break;
     }
 
     state->number_PRG_banks = PRG_banks;

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -182,7 +182,8 @@ void mapper069_reset(Mapper* mapper)
         state->ptr_PRG_bank_8K[0] = (uint8_t*)state->mROM->prg_base;
         state->ptr_PRG_bank_8K[1] = (uint8_t*)state->mROM->prg_base;
         state->ptr_PRG_bank_8K[2] = (uint8_t*)state->mROM->prg_base;
-        state->ptr_PRG_bank_8K[3] =
+        state->ptr_PRG_bank_8K[3] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_8K[4] =
             (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - (8U * 1024U)));
 
         state->ptr_CHR_bank_1K[0] = (uint8_t*)state->mROM->chr_base;
@@ -227,7 +228,6 @@ void mapper069_dumpState(Mapper* mapper, File& state)
     switch (s->backend)
     {
     case ROMBackend::LRU:
-    {
         for (int i = 0; i < 4; i++)
             PRG_bank_8K[i] = getBankIndex(&s->PRG_cache_8K, s->ptr_PRG_bank_8K[i]);
         for (int i = 0; i < 8; i++)
@@ -236,7 +236,6 @@ void mapper069_dumpState(Mapper* mapper, File& state)
         state.write(CHR_bank_1K, sizeof(CHR_bank_1K));
         state.write(s->RAM, 8U * 1024U);
         return;
-    }
 
     case ROMBackend::FLASH:
         for (int i = 0; i < 4; i++)
@@ -291,6 +290,8 @@ void mapper069_loadState(Mapper* mapper, File& state)
             s->ptr_PRG_bank_8K[i] = (uint8_t*)(s->mROM->prg_base + (PRG_bank_8K[i] * (8U * 1024U)));
         for (int i = 0; i < 8; i++)
             s->ptr_CHR_bank_1K[i] = (uint8_t*)(s->mROM->chr_base + (CHR_bank_1K[i] * (1U * 1024U)));
+
+        state.read(s->RAM, 8U * 1024U);
         return;
     }
 }
@@ -308,7 +309,7 @@ Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
     case ROMBackend::LRU:
         bankInit(&state->PRG_cache_8K, state->PRG_banks_8K, MAPPER069_NUM_PRG_BANKS_8K, 8U * 1024U,
                  cart);
-        bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER069_NUM_CHR_BANKS_1K, 1 * 1024,
+        bankInit(&state->CHR_cache_1K, state->CHR_banks_1K, MAPPER069_NUM_CHR_BANKS_1K, 1U * 1024,
                  cart);
         break;
 

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -38,7 +38,7 @@ constexpr Cartridge::MIRROR Mapper069_state::mirror[4];
 static inline uint8_t* getPRGBank(Mapper069_state* state, uint8_t index);
 static inline uint8_t* getCHRBank(Mapper069_state* state, uint8_t index);
 
-IRAM_ATTR bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr < 0x6000) return false;
 
@@ -62,7 +62,7 @@ IRAM_ATTR bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     if (addr < 0x6000) return false;
 
@@ -119,7 +119,7 @@ IRAM_ATTR bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
     return false;
 }
 
-IRAM_ATTR bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
     if (addr > 0x1FFF) return false;
 
@@ -129,7 +129,7 @@ IRAM_ATTR bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     return true;
 }
 
-IRAM_ATTR bool mapper069_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+bool mapper069_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
 {
     return false;
 }

--- a/src/core/mappers/mapper069.h
+++ b/src/core/mappers/mapper069.h
@@ -6,7 +6,7 @@
 #define MAPPER069_NUM_PRG_BANKS_8K 17
 #define MAPPER069_NUM_CHR_BANKS_1K 26
 
-Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, Cartridge* cart);
+Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);

--- a/src/core/mappers/mapper069.h
+++ b/src/core/mappers/mapper069.h
@@ -4,7 +4,7 @@
 #include "../mapper.h"
 
 #define MAPPER069_NUM_PRG_BANKS_8K 17
-#define MAPPER069_NUM_CHR_BANKS_1K 26
+#define MAPPER069_NUM_CHR_BANKS_1K 24
 
 Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 

--- a/src/core/rom_backends.h
+++ b/src/core/rom_backends.h
@@ -1,0 +1,12 @@
+#ifndef ROM_BACKENDS_H
+#define ROM_BACKENDS_H
+
+#include <stdint.h>
+
+enum class ROMBackend : uint8_t
+{
+    LRU,
+    FLASH
+};
+
+#endif

--- a/src/core/rom_types.h
+++ b/src/core/rom_types.h
@@ -1,0 +1,10 @@
+#ifndef ROM_TYPES_H
+#define ROM_TYPES_H
+
+enum class RomType
+{
+    PRG,
+    CHR
+};
+
+#endif

--- a/src/core/rom_types.h
+++ b/src/core/rom_types.h
@@ -1,7 +1,7 @@
 #ifndef ROM_TYPES_H
 #define ROM_TYPES_H
 
-enum class RomType
+enum class RomType : uint8_t
 {
     PRG,
     CHR

--- a/src/flash_mmap.cpp
+++ b/src/flash_mmap.cpp
@@ -1,0 +1,79 @@
+#include "flash_mmap.h"
+#include "core/cartridge.h"
+
+struct PartitionHeader
+{
+    uint32_t magic;
+    uint32_t crc32;
+};
+static constexpr uint32_t PART_MAGIC = 0x4E455321u; // 'NES!'
+
+bool mappedROM_init(MappedROM* rom, Cartridge* cart, uint32_t crc32, uint8_t num_prg_banks_16k,
+                    uint8_t num_chr_banks_8k)
+{
+    const esp_partition_t* ptr_partition =
+        esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "nesrom");
+    if (!ptr_partition)
+    {
+        LOG("[flash_mmap] 'nesrom' partition not found.");
+        return false;
+    }
+
+    const uint32_t prg_size = (uint32_t)num_prg_banks_16k * (16U * 1024U);
+    const uint32_t chr_size = (uint32_t)num_chr_banks_8k * (8U * 1024U);
+    const uint32_t body_size = prg_size + chr_size;
+
+    if (sizeof(PartitionHeader) + body_size > ptr_partition->size)
+    {
+        LOGF("[flash_mmap] ROM (%u B) exceeds partition (%u B)\n", (unsigned)body_size,
+             (unsigned)ptr_partition->size);
+        return false;
+    }
+
+    // Write only if ROM is different from previously loaded one (based on CRC32)
+    PartitionHeader stored = {};
+    esp_partition_read(ptr_partition, 0, &stored, sizeof(stored));
+    if (stored.magic != PART_MAGIC || stored.crc32 != crc32)
+    {
+        LOG("[flash_mmap] Writing ROM to flash...");
+
+        if (esp_partition_erase_range(ptr_partition, 0, ptr_partition->size) != ESP_OK)
+        {
+            LOG("[flash_mmap] Erase failed.");
+            return false;
+        }
+
+        {
+            uint8_t buf[4096];
+            PartitionHeader header = { PART_MAGIC, crc32 };
+            esp_partition_write(ptr_partition, 0, &header, sizeof(header));
+
+            cart->seek(16); // skip iNES header
+            for (uint32_t offset = sizeof(PartitionHeader),
+                          remaining = body_size + sizeof(PartitionHeader);
+                 offset < remaining; offset += sizeof(buf))
+            {
+                cart->read(buf, sizeof(buf));
+                esp_partition_write(ptr_partition, offset, buf, sizeof(buf));
+            }
+        }
+        LOG("[flash_mmap] Done.");
+    }
+    else LOG("[flash_mmap] ROM already in flash, skipping write.");
+
+    const void* mapped;
+    esp_err_t err = esp_partition_mmap(ptr_partition, 0, body_size + sizeof(PartitionHeader),
+                                       ESP_PARTITION_MMAP_DATA, &mapped, &rom->mmap_handle);
+    if (err != ESP_OK)
+    {
+        LOGF("[flash_mmap] mmap failed: %s\n", esp_err_to_name(err));
+        return false;
+    }
+
+    rom->prg_base = ((const uint8_t*)mapped) + sizeof(PartitionHeader);
+    rom->chr_base = rom->prg_base + prg_size;
+    rom->prg_size = prg_size;
+    rom->chr_size = chr_size;
+    LOGF("[flash_mmap] mmap result: %s, prg_base: %p\n", esp_err_to_name(err), rom->prg_base);
+    return true;
+}

--- a/src/flash_mmap.h
+++ b/src/flash_mmap.h
@@ -1,0 +1,25 @@
+#ifndef FLASH_MMAP_H
+#define FLASH_MMAP_H
+
+#include <Arduino.h>
+#include "debug.h"
+#include "esp_partition.h"
+#include "core/mapper.h"
+#include "core/rom_types.h"
+
+class Cartridge;
+struct MappedROM
+{
+    const uint8_t* prg_base;
+    const uint8_t* chr_base;
+    uint32_t prg_size;
+    uint32_t chr_size;
+    esp_partition_mmap_handle_t mmap_handle;
+};
+
+bool mappedROM_init(MappedROM* rom, Cartridge* cart, uint32_t crc32,
+                   uint8_t num_prg_banks_16k, uint8_t num_chr_banks_8k);
+
+IRAM_ATTR uint8_t ROM_read(const MappedROM* rom, const RomType type, const uint32_t offset);
+
+#endif

--- a/src/flash_mmap.h
+++ b/src/flash_mmap.h
@@ -20,6 +20,4 @@ struct MappedROM
 bool mappedROM_init(MappedROM* rom, Cartridge* cart, uint32_t crc32,
                    uint8_t num_prg_banks_16k, uint8_t num_chr_banks_8k);
 
-IRAM_ATTR uint8_t ROM_read(const MappedROM* rom, const RomType type, const uint32_t offset);
-
 #endif

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -193,7 +193,7 @@ void UI::drawBars()
     screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
     screen->print(selectText);
 
-    screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
+    screen->setTextColor(TFT_BLACK, BAR_COLOR);
     screen->print(currentMode);
 }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -17,6 +17,7 @@ Cartridge* UI::selectGame()
 
     drawWindowBox(2, 20, screen->width() - 4, screen->height() - 40);
     drawBars();
+    drawRomMode();
     getNesFiles();
     drawFileList();
 
@@ -63,6 +64,7 @@ Cartridge* UI::selectGame()
                 settings.rom_backend = (settings.rom_backend + 1) % 2;
                 saveSettings(&settings);
                 drawBars();
+                drawRomMode();
                 last_input_time = now;
             }
         }
@@ -172,29 +174,6 @@ void UI::drawBars()
 
     screen->setTextColor(TFT_BLACK, BAR_COLOR);
     screen->print(" Select");
-
-    const char* selectText = "Select";
-    const char* mode1 = " RAM mode";
-    const char* mode2 = " Flash mode";
-    const char* currentMode;
-    switch (settings.rom_backend)
-    {
-    case 0: currentMode = mode1; break;
-    case 1: currentMode = mode2; break;
-    default: currentMode = mode1; break;
-    }
-
-    const int16_t select_w = screen->textWidth(selectText);
-    const int16_t mode_w = screen->textWidth(currentMode);
-    const int16_t total_w = mode_w + select_w;
-    const int16_t mode_x = screen->width() - total_w - 8;
-    screen->setCursor(mode_x, y);
-
-    screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
-    screen->print(selectText);
-
-    screen->setTextColor(TFT_BLACK, BAR_COLOR);
-    screen->print(currentMode);
 }
 
 void UI::pauseMenu(Bus* nes)
@@ -621,4 +600,31 @@ void UI::drawText(const char* text, const int16_t x, const int16_t y)
     screen->setCursor(x, y);
     screen->setTextColor(TEXT2_COLOR);
     screen->print(text[0]);
+}
+
+void UI::drawRomMode()
+{
+    const int16_t y = screen->height() - 12;
+    const char* selectText = "Select";
+    const char* mode1 = " RAM mode";
+    const char* mode2 = " Flash mode";
+    const char* currentMode;
+    switch (settings.rom_backend)
+    {
+    case 0: currentMode = mode1; break;
+    case 1: currentMode = mode2; break;
+    default: currentMode = mode1; break;
+    }
+
+    const int16_t select_w = screen->textWidth(selectText);
+    const int16_t mode_w = screen->textWidth(currentMode);
+    const int16_t total_w = mode_w + select_w;
+    const int16_t mode_x = screen->width() - total_w - 8;
+    screen->setCursor(mode_x, y);
+
+    screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
+    screen->print(selectText);
+
+    screen->setTextColor(TFT_BLACK, BAR_COLOR);
+    screen->print(currentMode);
 }

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -63,6 +63,7 @@ Cartridge* UI::selectGame()
                 settings.rom_backend = (settings.rom_backend + 1) % 2;
                 saveSettings(&settings);
                 drawBars();
+                last_input_time = now;
             }
         }
 

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -57,13 +57,21 @@ Cartridge* UI::selectGame()
                 drawFileList();
                 last_input_time = now;
             }
+
+            if (isDownPressed(CONTROLLER::Select))
+            {
+                settings.rom_backend = (settings.rom_backend + 1) % 2;
+                saveSettings(&settings);
+                drawBars();
+            }
         }
 
         if (isDownPressed(CONTROLLER::A) && (selected >= 0 && selected < size))
         {
             std::string game = "/" + files[selected];
             std::vector<std::string>().swap(files);
-            return new Cartridge(game.c_str());
+            ROMBackend backend = (ROMBackend)settings.rom_backend;
+            return new Cartridge(game.c_str(), backend);
         }
     }
 }
@@ -148,8 +156,8 @@ void UI::drawBars()
     screen->fillRect(0, screen->height() - 16, screen->width(), 16, BAR_COLOR);
     screen->setTextColor(TFT_BLACK, BAR_COLOR);
 
-    int16_t y = screen->height() - 12;
-    int16_t x = 4;
+    const int16_t y = screen->height() - 12;
+    const int16_t x = 4;
 
     screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
     screen->setCursor(x, y);
@@ -163,6 +171,29 @@ void UI::drawBars()
 
     screen->setTextColor(TFT_BLACK, BAR_COLOR);
     screen->print(" Select");
+
+    const char* selectText = "Select";
+    const char* mode1 = " RAM mode";
+    const char* mode2 = " Flash mode";
+    const char* currentMode;
+    switch (settings.rom_backend)
+    {
+    case 0: currentMode = mode1; break;
+    case 1: currentMode = mode2; break;
+    default: currentMode = mode1; break;
+    }
+
+    const int16_t select_w = screen->textWidth(selectText);
+    const int16_t mode_w = screen->textWidth(currentMode);
+    const int16_t total_w = mode_w + select_w;
+    const int16_t mode_x = screen->width() - total_w - 8;
+    screen->setCursor(mode_x, y);
+
+    screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
+    screen->print(selectText);
+
+    screen->setTextColor(TEXT2_COLOR, BAR_COLOR);
+    screen->print(currentMode);
 }
 
 void UI::pauseMenu(Bus* nes)

--- a/src/ui.h
+++ b/src/ui.h
@@ -40,6 +40,7 @@ public:
 private:
     void setBrightness(int value);
     void drawText(const char* text, const int16_t x, const int16_t y);
+    void drawRomMode();
     TFT_eSPI* screen = nullptr;
     int selected = 0;
     int prev_selected = 0;

--- a/src/ui.h
+++ b/src/ui.h
@@ -6,6 +6,7 @@
 
 #include "controller.h"
 #include "core/bus.h"
+#include "core/rom_backends.h"
 #include "hwconfig.h"
 
 #define BL_CHANNEL          0
@@ -52,6 +53,7 @@ private:
         uint8_t volume = 100;
         uint8_t brightness = 100;
         uint8_t palette = 0;
+        uint8_t rom_backend = 0;
     };
     Settings settings;
     void saveSettings(const Settings* s);


### PR DESCRIPTION
## Overview
ROMs can now be stored directly in a dedicated `nesrom` flash partition and memory-mapped via `esp_partition_mmap()`. The ROM backend can be changed in the game selection screen by pressing the `Select` button. After the initial write, memory reads from the mapper class can read from the flash directly without having to load ROM data dynamically from the SD card. This offers an alternative way to run games that run too slow using the LRU cache implementation in RAM and also frees up ~190KB of RAM. This will allow for larger rendering buffers and will also pave the way for future features, such as composite video.

### ROM Backend

```C++
enum class ROMBackend : uint8_t
{
    LRU,
    FLASH
};
```
Adds ROM backend enum and a flash-mmap backend as an alternative to the existing LRU-DRAM bank cache for ROM access.

### Changes
- Added `flash_mmap.h/cpp` - writes ROM to `nesrom` partition (skipped if CRC32 matches) and mmaps it
- Added `rom_backend.h` - `ROMBackend` enum (`LRU`, `FLASH`) for runtime backend selection
- Added `rom_types.h` - `RomType` enum (`PRG`, `CHR`) for calculating memory locations and offsets.
- Updated `mapper000`, `mapper001`, `mapper003`, `mapper004`, and `mapper069` to support the flash backend for mapper read and writes
- Implemented save states for flash backend with cross compatibility between the LRU and flash backends
- Used a custom ESP32 partition scheme `partitions.csv` to add the 1 MB `nesrom` partition 

### New ESP32 Partition Layout
```
nvs        0x9000   0x5000
otadata    0xE000   0x2000
app0       0x10000  0x140000
app1       0x150000 0x140000
nesrom     0x290000 0x100000
spiffs     0x390000 0x60000
coredump   0x3F0000 0x10000
```

### Notes
- Flash mode should be as a last resort, such as when games run too slow on RAM mode, as it will cause wear on the ESP32's flash.
- Flash writes are skipped when the stored CRC32 matches the loaded ROM to reduce flash wear