### PR TITLE
feat: add composite video

### DIFF
--- a/Anemoia-ESP32.ino
+++ b/Anemoia-ESP32.ino
@@ -10,17 +10,21 @@
 #include "driver/i2s.h"
 #include "esp_bt.h"
 #include "esp_bt_main.h"
+#include "esp_task_wdt.h"
 #include "esp_wifi.h"
 #include "runtime_config.h"
+#include "src/composite_video.h"
 #include "src/controller.h"
 #include "src/core/bus.h"
 #include "src/debug.h"
 #include "src/ui.h"
 
 RuntimeConfig runtime_config;
-TFT_eSPI screen = TFT_eSPI();
 SPIClass SD_SPI(SD_SPI_PORT);
+#ifndef COMPOSITE_VIDEO
+TFT_eSPI screen = TFT_eSPI();
 UI ui(&screen);
+#endif
 Cartridge* cart;
 
 RTC_NOINIT_ATTR bool demo_mode_reset;
@@ -34,6 +38,7 @@ const uint64_t demo_mode_runtime = 120 * 1000000ULL; // 120 [seconds]
 void setup()
 {
     esp_reset_reason_t reset_reason = esp_reset_reason();
+    setCpuFrequencyMhz(240);
 #ifdef DEBUG
     Serial.begin(115200);
     log_pin_config();
@@ -49,6 +54,7 @@ void setup()
     esp_bt_mem_release(ESP_BT_MODE_BTDM);
     esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
 
+#ifndef COMPOSITE_VIDEO
     runtime_config = loadConfig();
 
     if (runtime_config.demo_mode)
@@ -88,16 +94,21 @@ void setup()
     // Initialize TFT screen
     screen.begin();
     screen.setRotation(runtime_config.rotation);
-#ifndef DISABLE_DMA
+    #ifndef DISABLE_DMA
     screen.initDMA();
-#endif
+    #endif
     screen.fillScreen(BG_COLOR);
     screen.startWrite();
+
+    ui.initializeSettings();
+#else
+    initCompositeVideo();
+    hw_config = loadConfig();
+#endif
 
     // Initialize microsd card
     if (!initSD())
         while (true);
-    ui.initializeSettings();
 
     // Setup buttons
     initController(runtime_config.controller_type);
@@ -105,7 +116,7 @@ void setup()
 
 void loop()
 {
-    cart = ui.selectGame();
+    cart = selectGame();
     if (cart && cart->isValid()) { emulate(); }
 
     invalidCartridge();
@@ -126,18 +137,21 @@ IRAM_ATTR void emulate()
 {
 
     Bus nes;
-    nes.insertCartridge(cart);
-    nes.connectScreen(&screen);
-    nes.reset();
+#ifdef COMPOSITE_VIDEO
+    nes.connectFramebuffer(cv_framebuffer);
+#else
     ui.loadEmulatorSettings(&nes);
+    nes.connectScreen(&screen);
+    screen.setAddrWindow(32, 0, 256, 240);
+#endif
+    nes.insertCartridge(cart);
+    nes.reset();
 
     TaskHandle_t apu_task_handle;
     xTaskCreatePinnedToCore(apuTask, "APU Task", 1024, &nes.cpu.apu, 1, &apu_task_handle, 0);
 
     TaskHandle_t polling_task_handle;
     xTaskCreatePinnedToCore(pollingTask, "Polling Task", 1024, &nes, 1, &polling_task_handle, 0);
-
-    screen.setAddrWindow(32, 0, 256, 240);
 
     LOGF("Free heap: %u bytes\n", heap_caps_get_free_size(MALLOC_CAP_DEFAULT));
     LOGF("Free DMA heap: %u bytes\n", heap_caps_get_free_size(MALLOC_CAP_DMA));
@@ -191,6 +205,7 @@ IRAM_ATTR void emulate()
         if ((nes.controller & (uint8_t)CONTROLLER::Start) &&
             (nes.controller & (uint8_t)CONTROLLER::Select))
         {
+#ifndef COMPOSITE_VIDEO
             if (!ui.paused)
             {
                 vTaskSuspend(apu_task_handle);
@@ -200,6 +215,14 @@ IRAM_ATTR void emulate()
                 nes.controller = 0;
                 screen.setAddrWindow(32, 0, 256, 240);
             }
+#else
+            if (!cv_paused)
+            {
+                cv_pauseMenu(&nes);
+                next_frame = esp_timer_get_time() + FRAME_TIME;
+                nes.controller = 0;
+            }
+#endif
         }
 
         // Generate one frame
@@ -228,8 +251,8 @@ IRAM_ATTR void emulate()
 #endif
         next_frame += FRAME_TIME;
     }
-#undef FRAME_TIME
 }
+#undef FRAME_TIME
 
 bool initSD()
 {
@@ -241,7 +264,7 @@ bool initSD()
         if (runtime_config.backlight) { ledcWrite(TFT_BACKLIGHT_PIN, 255); }
 
         LOG("SD Card Mount Failed");
-
+#ifndef COMPOSITE_VIDEO
         screen.setTextSize(2);
         const char* txt1 = "SD Init failed!";
         const char* txt2 = "Insert SD card or";
@@ -262,6 +285,7 @@ bool initSD()
         screen.drawString(txt2, x2, 88, 2);
         screen.drawString(txt3, x3, 120, 2);
         screen.drawString(txt4, x4, 152, 2);
+#endif
         return false;
     }
 
@@ -271,12 +295,14 @@ bool initSD()
 
 void invalidCartridge()
 {
+#ifndef COMPOSITE_VIDEO
     // Turn backlight on so error message can be seen
     if (runtime_config.backlight) { ledcWrite(TFT_BACKLIGHT_PIN, 255); }
     screen.fillScreen(BG_COLOR);
     screen.setTextColor(TFT_WHITE);
     screen.setTextDatum(MC_DATUM);
     screen.drawString("ROM Mapper not supported!", screen.width() / 2, screen.height() / 2, 2);
+#endif
     delay(3000);
     ESP.restart();
 }
@@ -339,7 +365,14 @@ void apuTask(void* param)
 {
     Apu2A03* apu = (Apu2A03*)param;
 
-    while (true) { apu->clock(); }
+    while (true)
+    {
+#ifndef COMPOSITE_VIDEO
+        apu->clock();
+#else
+        vTaskDelay(1000000000);
+#endif
+    }
 }
 
 void pollingTask(void* param)
@@ -355,4 +388,32 @@ void pollingTask(void* param)
 
         vTaskDelayUntil(&lastWakeTime, frameTicks);
     }
+}
+
+static SemaphoreHandle_t video_init_done;
+void videoInitTask(void* param)
+{
+    video_init(VIDEO_STANDARD);
+    xSemaphoreGive(video_init_done);
+    vTaskDelete(NULL);
+}
+
+void initCompositeVideo()
+{
+    // Initialize composite video output on core 0 to avoid contention with emulation tasks
+    video_init_done = xSemaphoreCreateBinary();
+
+    xTaskCreatePinnedToCore(videoInitTask, "VidInit", 8192, nullptr, 1, NULL, 0);
+
+    xSemaphoreTake(video_init_done, portMAX_DELAY);
+    vSemaphoreDelete(video_init_done);
+}
+
+Cartridge* selectGame()
+{
+#ifdef COMPOSITE_VIDEO
+    return cv_selectGame();
+#else
+    return ui.selectGame();
+#endif
 }

--- a/Anemoia-ESP32.ino
+++ b/Anemoia-ESP32.ino
@@ -365,14 +365,7 @@ void apuTask(void* param)
 {
     Apu2A03* apu = (Apu2A03*)param;
 
-    while (true)
-    {
-#ifndef COMPOSITE_VIDEO
-        apu->clock();
-#else
-        vTaskDelay(1000000000);
-#endif
-    }
+    while (true) { apu->clock(); }
 }
 
 void pollingTask(void* param)

--- a/Anemoia-ESP32.ino
+++ b/Anemoia-ESP32.ino
@@ -218,7 +218,9 @@ IRAM_ATTR void emulate()
 #else
             if (!cv_paused)
             {
+                vTaskSuspend(apu_task_handle);
                 cv_pauseMenu(&nes);
+                vTaskResume(apu_task_handle);
                 next_frame = esp_timer_get_time() + FRAME_TIME;
                 nes.controller = 0;
             }

--- a/Anemoia-ESP32.ino
+++ b/Anemoia-ESP32.ino
@@ -54,9 +54,8 @@ void setup()
     esp_bt_mem_release(ESP_BT_MODE_BTDM);
     esp_bt_controller_mem_release(ESP_BT_MODE_BTDM);
 
-#ifndef COMPOSITE_VIDEO
     runtime_config = loadConfig();
-
+#ifndef COMPOSITE_VIDEO
     if (runtime_config.demo_mode)
     {
         if (reset_reason == ESP_RST_SW)
@@ -103,7 +102,6 @@ void setup()
     ui.initializeSettings();
 #else
     initCompositeVideo();
-    hw_config = loadConfig();
 #endif
 
     // Initialize microsd card
@@ -124,7 +122,9 @@ void loop()
 
 IRAM_ATTR void onTimer()
 {
+#ifndef COMPOSITE_VIDEO
     ui.restoreBrightness();
+#endif
 }
 
 #ifdef DEBUG
@@ -135,7 +135,6 @@ unsigned long frame_count = 0;
 #endif
 IRAM_ATTR void emulate()
 {
-
     Bus nes;
 #ifdef COMPOSITE_VIDEO
     nes.connectFramebuffer(cv_framebuffer);

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Want to make a PCB? NextPCB offers PCB fabrication and assembly services with fa
 - [Performance](#performance)
 - [Compatibility](#compatibility)
 - [Hardware Overview](#hardware-overview)
+  - [Composite Video Output](#composite-video-output)
   - [Original Hardware](#original-hardware)
   - [Cheap Yellow Display](#cheap-yellow-display)
   - [Custom-made PCBs](#custom-made-pcbs)
@@ -102,9 +103,52 @@ Feel free to open an issue if a game has glitches or fails to boot.
 ---
 
 ## Hardware Overview
+Anemoia-ESP32 requires a dual-core ESP32 with a minimum of 1 MB flash memory and <u><strong>NO PSRAM IS REQUIRED</strong></u>.
+
+### Composite Video Output
+
+Anemoia-ESP32 supports composite video output via the `COMPOSITE_VIDEO` build flag, based on [esp_8_bit](https://github.com/rossumur/esp_8_bit) by Peter Barrett. This lets the emulator output directly to a CRT television or any display with a composite input — no SPI display required.
+
+**Additional hardware needed:**
+- Any CRT or display with a composite RCA input
+- 1kΩ resistor and 10nF capacitor (for the audio RC filter)
+
+**Wiring:**
+-----------
+|         |
+|      25 |-------------------------------► Video out (RCA)
+|         |
+|      18 |----[1kΩ]----+---------------► Audio out
+|  ESP32  |             |
+|         |            ---
+|         |            --- 10nF
+|         |             |
+|         |             ▼ GND
+-----------
+
+| Signal    | ESP32 Pin |
+|-----------|-----------|
+| Video out | GPIO25    |
+| Audio out | GPIO18    |
+
+> [!NOTE]
+> GPIO18 is the default audio pin and can be changed via `AUDIO_PIN` in `config.h`.
+
+To enable composite video, open `config.h` and uncomment:
+```cpp
+#define COMPOSITE_VIDEO
+```
+
+Then set your video standard and audio pin as needed:
+```cpp
+#define VIDEO_STANDARD 1  // 0 = PAL, 1 = NTSC
+#define AUDIO_PIN      18
+```
+
+> [!IMPORTANT]
+> Composite video and TFT output are mutually exclusive. Enabling `COMPOSITE_VIDEO` disables the SPI display pipeline entirely.
 
 ### Original Hardware
-Anemoia-ESP32 requires a dual-core ESP32 with a minimum of 1 MB flash memory and <u><strong>NO PSRAM IS REQUIRED</strong></u>.
 
 - ESP32
   - e.g. ESP32-DevKitC or ESP32-WROOM-32

--- a/README.md
+++ b/README.md
@@ -107,13 +107,14 @@ Anemoia-ESP32 requires a dual-core ESP32 with a minimum of 1 MB flash memory and
 
 ### Composite Video Output
 
-Anemoia-ESP32 supports composite video output via the `COMPOSITE_VIDEO` build flag, based on [esp_8_bit](https://github.com/rossumur/esp_8_bit) by Peter Barrett. This lets the emulator output directly to a CRT television or any display with a composite input — no SPI display required.
+Anemoia-ESP32 supports composite video output via the `COMPOSITE_VIDEO` define in `config.h`, based on [esp_8_bit](https://github.com/rossumur/esp_8_bit) by Peter Barrett. This lets the emulator output directly to a CRT television or any display with a composite input.
 
 **Additional hardware needed:**
 - Any CRT or display with a composite RCA input
-- 1kΩ resistor and 10nF capacitor (for the audio RC filter)
+- 1kΩ resistor and 10nF capacitor
 
 **Wiring:**
+```
 -----------
 |         |
 |      25 |-------------------------------► Video out (RCA)
@@ -125,6 +126,7 @@ Anemoia-ESP32 supports composite video output via the `COMPOSITE_VIDEO` build fl
 |         |             |
 |         |             ▼ GND
 -----------
+```
 
 | Signal    | ESP32 Pin |
 |-----------|-----------|

--- a/config.h
+++ b/config.h
@@ -1,6 +1,11 @@
 #ifndef CONFIG_H
 #define CONFIG_H
 
+// Uncomment if you are using composite video output instead of a TFT display
+#define COMPOSITE_VIDEO
+#define VIDEO_STANDARD 1 // 0 = PAL, 1 = NTSC
+#define AUDIO_PIN      18
+
 // #define CHEAP_YELLOW_DISPLAY_CONF // Uncomment this line if using the CYD
 // #define MODULE_BASED_PCB_CONF // Uncomment this line if using the module PCB
 // #define DISCRETE_PCB_CONF // Uncomment this line if using the discrete PCB

--- a/src/composite_video.h
+++ b/src/composite_video.h
@@ -222,7 +222,7 @@ void video_init_hw(int line_width, int samples_per_cc)
     //                   v gnd
 
     // ledcAttach(AUDIO_PIN, 2000000, 7); // 625000 khz is as fast as we go w 7 bits
-    ledcAttach(AUDIO_PIN, 625000, 7);
+    ledcAttachChannel(AUDIO_PIN, 625000, 7, 0);
     ledcWrite(0, 0);
 }
 
@@ -540,8 +540,8 @@ void IRAM_ATTR pal_sync(uint16_t* line, int i)
     pal_sync2(line + _line_width / 2, _line_width / 2, t & 1);
 }
 
-//  audio is buffered as 6 bit unsigned samples
-uint8_t _audio_buffer[128];
+// audio is buffered as 6 bit unsigned samples
+uint8_t _audio_buffer[1024];
 uint32_t _audio_r = 0;
 uint32_t _audio_w = 0;
 void audio_write_16(const int16_t* s, int len, int channels)
@@ -580,11 +580,9 @@ void video_sync()
 
 void IRAM_ATTR video_isr(volatile void* vbuf)
 {
-    if (!_framebuffer) return;
-
-    // uint8_t s =
-    //     _audio_r < _audio_w ? _audio_buffer[_audio_r++ & (sizeof(_audio_buffer) - 1)] : 0x20;
-    // audio_sample(s);
+    uint8_t s =
+        _audio_r < _audio_w ? _audio_buffer[_audio_r++ & (sizeof(_audio_buffer) - 1)] : 0x20;
+    audio_sample(s);
     // audio_sample(_sin64[_x++ & 0x3F]);
 
     int i = _line_counter++;

--- a/src/composite_video.h
+++ b/src/composite_video.h
@@ -575,7 +575,7 @@ void IRAM_ATTR pal_sync(uint16_t* line, int i)
 uint8_t _audio_buffer[1024];
 uint32_t _audio_r = 0;
 uint32_t _audio_w = 0;
-void audio_write_16(const uint16_t* s, int len, int channels)
+void cv_audio_write_16(const uint16_t* s, int len, int channels)
 {
     int b;
     while (len--)
@@ -591,6 +591,11 @@ void audio_write_16(const uint16_t* s, int len, int channels)
         if (b > 127) b = 127;
         _audio_buffer[_audio_w++ & (sizeof(_audio_buffer) - 1)] = b;
     }
+}
+
+bool cv_audio_buffer_full(int buffer_size)
+{
+    return (_audio_w - _audio_r) + buffer_size > sizeof(_audio_buffer);
 }
 
 // Wait for blanking before starting drawing

--- a/src/composite_video.h
+++ b/src/composite_video.h
@@ -587,9 +587,10 @@ void audio_write_16(const int16_t* s, int len, int channels)
             s += 2;
         }
         else b = *s++ >> 8;
-        if (b < -32) b = -32;
-        if (b > 31) b = 31;
-        _audio_buffer[_audio_w++ & (sizeof(_audio_buffer) - 1)] = b + 32;
+        b >>= 1; // scale [0, 255] down to [0, 127]
+        if (b < 0) b = 0;
+        if (b > 127) b = 127;
+        _audio_buffer[_audio_w++ & (sizeof(_audio_buffer) - 1)] = b;
     }
 }
 
@@ -612,7 +613,7 @@ void video_sync()
 void IRAM_ATTR video_isr(volatile void* vbuf)
 {
     uint8_t s =
-        _audio_r < _audio_w ? _audio_buffer[_audio_r++ & (sizeof(_audio_buffer) - 1)] : 0x20;
+        _audio_r < _audio_w ? _audio_buffer[_audio_r++ & (sizeof(_audio_buffer) - 1)] : 0x40;
     audio_sample(s);
     // audio_sample(_sin64[_x++ & 0x3F]);
 

--- a/src/composite_video.h
+++ b/src/composite_video.h
@@ -575,7 +575,7 @@ void IRAM_ATTR pal_sync(uint16_t* line, int i)
 uint8_t _audio_buffer[1024];
 uint32_t _audio_r = 0;
 uint32_t _audio_w = 0;
-void audio_write_16(const int16_t* s, int len, int channels)
+void audio_write_16(const uint16_t* s, int len, int channels)
 {
     int b;
     while (len--)
@@ -588,7 +588,6 @@ void audio_write_16(const int16_t* s, int len, int channels)
         }
         else b = *s++ >> 8;
         b >>= 1; // scale [0, 255] down to [0, 127]
-        if (b < 0) b = 0;
         if (b > 127) b = 127;
         _audio_buffer[_audio_w++ & (sizeof(_audio_buffer) - 1)] = b;
     }

--- a/src/composite_video.h
+++ b/src/composite_video.h
@@ -150,16 +150,48 @@ static esp_err_t composite_video_start_dma(int line_width, int samples_per_cc, i
     I2S0.out_link.addr = (uint32_t)_dma_desc;
 
     //  Setup up the apll: See ref 3.2.7 Audio PLL
-    //  f_xtal = (int)rtc_clk_xtal_freq_get() * 1000000;
-    //  f_out = xtal_freq * (4 + sdm2 + sdm1/256 + sdm0/65536); // 250 < f_out < 500
-    //  apll_freq = f_out/((o_div + 2) * 2)
-    //  operating range of the f_out is 250 MHz ~ 500 MHz
-    //  operating range of the apll_freq is 16 ~ 128 MHz.
-    //  select sdm0,sdm1,sdm2 to produce nice multiples of colorburst frequencies
+    // Formula:
+    // vco = 40000000 * (4 + sdm2 + sdm1/256 + sdm0/65536);
+    // apll_freq = f_out / ((o_div + 2) * 2);
+    // dac_freq = apll_freq / 4; // <- This is the output frequency of GPIO25
+    // operating range of the f_out is 250 MHz ~ 500 MHz
+    // operating range of the apll_freq is 16 ~ 128 MHz.
+    // select sdm0,sdm1,sdm2 to produce nice multiples of colorburst frequencies
 
-    //  see calc_freq() for math: (4+a)*10/((2 + b)*2) mhz
-    //  up to 20mhz seems to work ok:
-    //  rtc_clk_apll_enable(1,0x00,0x00,0x4,0);   // 20mhz for fancy DDS
+    // Calculations for the closest possible frequency
+    // These coefficients should supposedly be more accurate than the original coefficients used
+    // === NTSC_3x (target = 10.7386363636 MHz) ===
+    //   o_div = 2
+    //   sdm2  = 4
+    //   sdm1  = 151
+    //   sdm0  = 70
+    //   vco   = 343.6364746094 MHz  (valid: 250-500 MHz)
+    //   apll  = 42.9545593262 MHz
+    //   dac   = 10738639.8315429688 Hz
+    //   error = +3.467943 Hz
+    //   rtc_clk_apll_coeff_set(2, 70, 151, 4);
+
+    // === NTSC_4x (target = 14.3181818182 MHz) ===
+    //   o_div = 2
+    //   sdm2  = 7
+    //   sdm1  = 116
+    //   sdm0  = 93
+    //   vco   = 458.1817626953 MHz  (valid: 250-500 MHz)
+    //   apll  = 57.2727203369 MHz
+    //   dac   = 14318180.0842285156 Hz
+    //   error = -1.733971 Hz
+    //   rtc_clk_apll_coeff_set(2, 93, 116, 7);
+
+    // === PAL_4x (target = 17.7344760000 MHz) ===
+    //   o_div = 1
+    //   sdm2  = 6
+    //   sdm1  = 164
+    //   sdm0  = 4
+    //   vco   = 425.6274414062 MHz  (valid: 250-500 MHz)
+    //   apll  = 70.9379069010 MHz
+    //   dac   = 17734476.7252604179 Hz
+    //   error = +0.725260 Hz
+    //   rtc_clk_apll_coeff_set(1, 4, 164, 6);
 
     rtc_clk_apll_enable(1);
     if (!_pal_)
@@ -167,13 +199,12 @@ static esp_err_t composite_video_start_dma(int line_width, int samples_per_cc, i
         switch (samples_per_cc)
         {
         case 3:
-            // rtc_clk_apll_coeff_set(2, 0x46, 0x97, 0x4);
-            rtc_clk_apll_coeff_set(3, 95, 133, 12); // Supposedly more accurate version
-            break;                                  // 10.7386363636 3x NTSC (10.7386398315mhz)
+            rtc_clk_apll_coeff_set(2, 0x46, 0x97, 0x4);
+            break; // 10.7386363636 3x NTSC (10.7386398315mhz)
         case 4:
-            rtc_clk_apll_coeff_set(1, 0x46, 0x97, 0x4);
-            // rtc_clk_apll_coeff_set(2, 93, 116, 7);
-            break; // 14.3181818182 4x NTSC (14.3181864421mhz)
+            // rtc_clk_apll_coeff_set(1, 0x46, 0x97, 0x4);
+            rtc_clk_apll_coeff_set(2, 93, 116, 7); // Supposedly more accurate version
+            break;                                 // 14.3181818182 4x NTSC (14.3181864421mhz)
         }
     }
     else

--- a/src/composite_video.h
+++ b/src/composite_video.h
@@ -1,0 +1,1085 @@
+// Credit to Peter Barrett for his research and work on composite video generation using the ESP32.
+// This code is based on his work and has been adapted for use in this project.
+// All credit for the composite video generation goes to him.
+// https://github.com/rossumur/esp_8_bit
+
+/* Copyright (c) 2020, Peter Barrett
+**
+** Permission to use, copy, modify, and/or distribute this software for
+** any purpose with or without fee is hereby granted, provided that the
+** above copyright notice and this permission notice appear in all copies.
+**
+** THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+** WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+** WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR
+** BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES
+** OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
+** WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION,
+** ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+** SOFTWARE.
+*/
+
+#ifndef COMPOSITE_VIDEO_H
+#define COMPOSITE_VIDEO_H
+
+#include "../config.h"
+#include "controller.h"
+#include "core/bus.h"
+#include "core/cartridge.h"
+#include "core/rom_backends.h"
+#include "driver/dac.h"
+#include "driver/gpio.h"
+#include "driver/i2s.h"
+#include "driver/periph_ctrl.h"
+#include "esp_attr.h"
+#include "esp_err.h"
+#include "esp_heap_caps.h"
+#include "esp_intr_alloc.h"
+#include "esp_types.h"
+#include "rom/gpio.h"
+#include "rom/lldesc.h"
+#include "soc/efuse_periph.h"
+#include "soc/efuse_reg.h"
+#include "soc/gpio_reg.h"
+#include "soc/i2s_reg.h"
+#include "soc/i2s_struct.h"
+#include "soc/io_mux_reg.h"
+#include "soc/ledc_struct.h"
+#include "soc/rtc.h"
+#include "soc/rtc_io_reg.h"
+#include "soc/soc.h"
+#include <stdint.h>
+
+static const int screen_width = 256;
+static const int screen_height = 240;
+uint8_t cv_framebuffer[screen_width * screen_height];
+
+// https://wiki.nesdev.com/w/index.php/NTSC_video
+// // NES/SMS have pixel rates of 5.3693175, or 2/3 color clock
+// // in 3 phase mode each pixel gets 2 DAC values written, 2 color clocks = 3 nes pixels
+static const DRAM_ATTR uint32_t nes_3_phase[64] = {
+    0x2C2C2C00, 0x241D2400, 0x221D2600, 0x1F1F2700, 0x1D222600, 0x1D242400, 0x1D262200, 0x1F271F00,
+    0x22261D00, 0x24241D00, 0x26221D00, 0x271F1F00, 0x261D2200, 0x14141400, 0x14141400, 0x14141400,
+    0x38383800, 0x2C252C00, 0x2A252E00, 0x27272F00, 0x252A2E00, 0x252C2C00, 0x252E2A00, 0x272F2700,
+    0x2A2E2500, 0x2C2C2500, 0x2E2A2500, 0x2F272700, 0x2E252A00, 0x1F1F1F00, 0x15151500, 0x15151500,
+    0x45454500, 0x3A323A00, 0x37333C00, 0x35353C00, 0x33373C00, 0x323A3A00, 0x333C3700, 0x353C3500,
+    0x373C3300, 0x3A3A3200, 0x3C373300, 0x3C353500, 0x3C333700, 0x2B2B2B00, 0x16161600, 0x16161600,
+    0x45454500, 0x423B4200, 0x403B4400, 0x3D3D4500, 0x3B404400, 0x3B424200, 0x3B444000, 0x3D453D00,
+    0x40443B00, 0x42423B00, 0x44403B00, 0x453D3D00, 0x443B4000, 0x39393900, 0x17171700, 0x17171700,
+};
+static const DRAM_ATTR uint32_t nes_4_phase[64] = {
+    0x2C2C2C2C, 0x241D1F26, 0x221D2227, 0x1F1D2426, 0x1D1F2624, 0x1D222722, 0x1D24261F, 0x1F26241D,
+    0x2227221D, 0x24261F1D, 0x26241D1F, 0x27221D22, 0x261F1D24, 0x14141414, 0x14141414, 0x14141414,
+    0x38383838, 0x2C25272E, 0x2A252A2F, 0x27252C2E, 0x25272E2C, 0x252A2F2A, 0x252C2E27, 0x272E2C25,
+    0x2A2F2A25, 0x2C2E2725, 0x2E2C2527, 0x2F2A252A, 0x2E27252C, 0x1F1F1F1F, 0x15151515, 0x15151515,
+    0x45454545, 0x3A33353C, 0x3732373C, 0x35333A3C, 0x33353C3A, 0x32373C37, 0x333A3C35, 0x353C3A33,
+    0x373C3732, 0x3A3C3533, 0x3C3A3335, 0x3C373237, 0x3C35333A, 0x2B2B2B2B, 0x16161616, 0x16161616,
+    0x45454545, 0x423B3D44, 0x403B4045, 0x3D3B4244, 0x3B3D4442, 0x3B404540, 0x3B42443D, 0x3D44423B,
+    0x4045403B, 0x42443D3B, 0x44423B3D, 0x45403B40, 0x443D3B42, 0x39393939, 0x17171717, 0x17171717,
+};
+static const DRAM_ATTR uint32_t nes_yuv_4_phase_pal[] = {
+    0x31313131, 0x2D21202B, 0x2720252D, 0x21212B2C, 0x1D23302A, 0x1B263127, 0x1C293023, 0x202B2D22,
+    0x262B2722, 0x2C2B2122, 0x2F2B1E23, 0x31291F27, 0x30251F2A, 0x18181818, 0x19191919, 0x19191919,
+    0x3D3D3D3D, 0x34292833, 0x2F282D34, 0x29283334, 0x252B3732, 0x232E392E, 0x2431382B, 0x28333429,
+    0x2D342F28, 0x33342928, 0x3732252A, 0x392E232E, 0x382B2431, 0x24242424, 0x1A1A1A1A, 0x1A1A1A1A,
+    0x49494949, 0x42373540, 0x3C373B40, 0x36374040, 0x3337433F, 0x3139433B, 0x323D4338, 0x35414237,
+    0x3B423D35, 0x41413736, 0x453F3238, 0x473C313B, 0x4639323F, 0x2F2F2F2F, 0x1A1A1A1A, 0x1A1A1A1A,
+    0x49494949, 0x48413D45, 0x42404345, 0x3D3F4644, 0x3B3D4543, 0x3B3E4542, 0x3B42453F, 0x3E47463E,
+    0x434A453E, 0x46483E3D, 0x4843393E, 0x4A403842, 0x4B403944, 0x3E3E3E3E, 0x1B1B1B1B, 0x1B1B1B1B,
+    0x31313131, 0x20212D2B, 0x2520272D, 0x2B21212C, 0x30231D2A, 0x31261B27, 0x30291C23, 0x2D2B2022,
+    0x272B2622, 0x212B2C22, 0x1E2B2F23, 0x1F293127, 0x1F25302A, 0x18181818, 0x19191919, 0x19191919,
+    0x3D3D3D3D, 0x28293433, 0x2D282F34, 0x33282934, 0x372B2532, 0x392E232E, 0x3831242B, 0x34332829,
+    0x2F342D28, 0x29343328, 0x2532372A, 0x232E392E, 0x242B3831, 0x24242424, 0x1A1A1A1A, 0x1A1A1A1A,
+    0x49494949, 0x35374240, 0x3B373C40, 0x40373640, 0x4337333F, 0x4339313B, 0x433D3238, 0x42413537,
+    0x3D423B35, 0x37414136, 0x323F4538, 0x313C473B, 0x3239463F, 0x2F2F2F2F, 0x1A1A1A1A, 0x1A1A1A1A,
+    0x49494949, 0x3D414845, 0x43404245, 0x463F3D44, 0x453D3B43, 0x453E3B42, 0x45423B3F, 0x46473E3E,
+    0x454A433E, 0x3E48463D, 0x3943483E, 0x38404A42, 0x39404B44, 0x3E3E3E3E, 0x1B1B1B1B, 0x1B1B1B1B,
+};
+
+static int _pal_ = 0;
+
+static lldesc_t _dma_desc[2] = { 0 };
+static intr_handle_t _isr_handle;
+void IRAM_ATTR video_isr(volatile void* buf);
+void IRAM_ATTR i2s_intr_handler_video(void* arg)
+{
+    if (I2S0.int_st.out_eof)
+        video_isr(
+            (volatile void*)((lldesc_t*)I2S0.out_eof_des_addr)->buf); // get the next line of video
+    I2S0.int_clr.val = I2S0.int_st.val;                               // reset the interrupt
+}
+
+static esp_err_t composite_video_start_dma(int line_width, int samples_per_cc, int ch = 1)
+{
+    periph_module_enable(PERIPH_I2S0_MODULE);
+
+    // setup interrupt
+    if (esp_intr_alloc(ETS_I2S0_INTR_SOURCE, ESP_INTR_FLAG_LEVEL1 | ESP_INTR_FLAG_IRAM,
+                       i2s_intr_handler_video, 0, &_isr_handle) != ESP_OK)
+        return -1;
+
+    // reset conf
+    I2S0.conf.val = 1;
+    I2S0.conf.val = 0;
+    I2S0.conf.tx_right_first = 1;
+    I2S0.conf.tx_mono = (ch == 2 ? 0 : 1);
+
+    I2S0.conf2.lcd_en = 1;
+    I2S0.fifo_conf.tx_fifo_mod_force_en = 1;
+    I2S0.sample_rate_conf.tx_bits_mod = 16;
+    I2S0.conf_chan.tx_chan_mod = (ch == 2) ? 0 : 1;
+
+    // Create TX DMA buffers
+    for (int i = 0; i < 2; i++)
+    {
+        int n = line_width * 2 * ch;
+        if (n >= 4092)
+        {
+            printf("DMA chunk too big:%s\n", n);
+            return -1;
+        }
+        _dma_desc[i].buf = (uint8_t*)heap_caps_calloc(1, n, MALLOC_CAP_DMA);
+        if (!_dma_desc[i].buf) return -1;
+
+        _dma_desc[i].owner = 1;
+        _dma_desc[i].eof = 1;
+        _dma_desc[i].length = n;
+        _dma_desc[i].size = n;
+        _dma_desc[i].empty = (uint32_t)(i == 1 ? _dma_desc : _dma_desc + 1);
+    }
+    I2S0.out_link.addr = (uint32_t)_dma_desc;
+
+    //  Setup up the apll: See ref 3.2.7 Audio PLL
+    //  f_xtal = (int)rtc_clk_xtal_freq_get() * 1000000;
+    //  f_out = xtal_freq * (4 + sdm2 + sdm1/256 + sdm0/65536); // 250 < f_out < 500
+    //  apll_freq = f_out/((o_div + 2) * 2)
+    //  operating range of the f_out is 250 MHz ~ 500 MHz
+    //  operating range of the apll_freq is 16 ~ 128 MHz.
+    //  select sdm0,sdm1,sdm2 to produce nice multiples of colorburst frequencies
+
+    //  see calc_freq() for math: (4+a)*10/((2 + b)*2) mhz
+    //  up to 20mhz seems to work ok:
+    //  rtc_clk_apll_enable(1,0x00,0x00,0x4,0);   // 20mhz for fancy DDS
+
+    rtc_clk_apll_enable(1);
+    if (!_pal_)
+    {
+        switch (samples_per_cc)
+        {
+        case 3:
+            // rtc_clk_apll_coeff_set(2, 0x46, 0x97, 0x4);
+            rtc_clk_apll_coeff_set(3, 95, 133, 12); // Supposedly more accurate version
+            break;                                  // 10.7386363636 3x NTSC (10.7386398315mhz)
+        case 4:
+            rtc_clk_apll_coeff_set(1, 0x46, 0x97, 0x4);
+            // rtc_clk_apll_coeff_set(2, 93, 116, 7);
+            break; // 14.3181818182 4x NTSC (14.3181864421mhz)
+        }
+    }
+    else
+    {
+        rtc_clk_apll_coeff_set(1, 0x04, 0xA4, 0x6); // 17.734476mhz ~4x PAL
+    }
+
+    I2S0.clkm_conf.clkm_div_num = 1; // I2S clock divider’s integral value.
+    I2S0.clkm_conf.clkm_div_b = 0;   // Fractional clock divider’s numerator value.
+    I2S0.clkm_conf.clkm_div_a = 1;   // Fractional clock divider’s denominator value
+    I2S0.sample_rate_conf.tx_bck_div_num = 1;
+    I2S0.clkm_conf.clka_en = 1;                     // Set this bit to enable clk_apll.
+    I2S0.fifo_conf.tx_fifo_mod = (ch == 2) ? 0 : 1; // 32-bit dual or 16-bit single channel data
+
+    dac_output_enable(DAC_CHANNEL_1);
+    dac_i2s_enable();
+
+    I2S0.conf.tx_start = 1;
+    I2S0.int_clr.val = 0xFFFFFFFF;
+    I2S0.int_ena.out_eof = 1;
+    I2S0.out_link.start = 1;
+    return esp_intr_enable(_isr_handle); // start interruprs!
+}
+
+void video_init_hw(int line_width, int samples_per_cc)
+{
+    // setup apll 4x NTSC or PAL colorburst rate
+    composite_video_start_dma(line_width, samples_per_cc, 1);
+
+    // Now ideally we would like to use the decoupled left DAC channel to produce audio
+    // But when using the APLL there appears to be some clock domain conflict that causes
+    // nasty digitial spikes and dropouts. You are also limited to a single audio channel.
+    // So it is back to PWM/PDM and a 1 bit DAC for us. Good news is that we can do stereo
+    // if we want to and have lots of different ways of doing nice noise shaping etc.
+
+    // PWM audio out of pin 18 -> can be anything
+    // lots of other ways, PDM by hand over I2S1, spi circular buffer etc
+    // but if you would like stereo the led pwm seems like a fine choice
+    // needs a simple rc filter (1k->1.2k resistor & 10nf->15nf cap work fine)
+
+    // 18 ----/\/\/\/----|------- a out
+    //          1k       |
+    //                  ---
+    //                  --- 10nf
+    //                   |
+    //                   v gnd
+
+    // ledcAttach(AUDIO_PIN, 2000000, 7); // 625000 khz is as fast as we go w 7 bits
+    ledcAttach(AUDIO_PIN, 625000, 7);
+    ledcWrite(0, 0);
+}
+
+// send an audio sample every scanline (15720hz for ntsc, 15600hz for PAL)
+inline void IRAM_ATTR audio_sample(uint8_t s)
+{
+    auto& reg = LEDC.channel_group[0].channel[0];
+    reg.duty.duty = s << 4;   // 25 bit (21.4)
+    reg.conf0.sig_out_en = 1; // This is the output enable control bit for channel
+    reg.conf1.duty_start =
+        1; // When duty_num duty_cycle and duty_scale has been configured. these register won't take
+           // effect until set duty_start. this bit is automatically cleared by hardware
+    reg.conf0.clk_en = 1;
+}
+
+//====================================================================================================
+//====================================================================================================
+
+uint32_t cpu_ticks()
+{
+    return xthal_get_ccount();
+}
+
+uint32_t us()
+{
+    return cpu_ticks() / 240;
+}
+
+// Color clock frequency is 315/88 (3.57954545455)
+// DAC_MHZ is 315/11 or 8x color clock
+// 455/2 color clocks per line, round up to maintain phase
+// HSYNCH period is 44/315*455 or 63.55555..us
+// Field period is 262*44/315*455 or 16651.5555us
+
+#define IRE(_x)        ((uint32_t)(((_x) + 40) * 255 / 3.3 / 147.5) << 8) // 3.3V DAC
+#define SYNC_LEVEL     IRE(-40)
+#define BLANKING_LEVEL IRE(0)
+#define BLACK_LEVEL    IRE(7.5)
+#define GRAY_LEVEL     IRE(50)
+#define WHITE_LEVEL    IRE(100)
+
+#define P0             (color >> 16)
+#define P1             (color >> 8)
+#define P2             (color)
+#define P3             (color << 8)
+
+static uint8_t* _framebuffer;
+volatile int _line_counter = 0;
+volatile int _frame_counter = 0;
+
+static int _active_lines;
+static int _line_count;
+
+static int _line_width;
+static int _samples_per_cc;
+static const uint32_t* _palette;
+
+static float _sample_rate;
+
+static int _hsync;
+static int _hsync_long;
+static int _hsync_short;
+static int _burst_start;
+static int _burst_width;
+static int _active_start;
+
+static int16_t* _burst0 = 0; // pal bursts
+static int16_t* _burst1 = 0;
+
+static int usec(float us)
+{
+    uint32_t r = (uint32_t)(us * _sample_rate);
+    return ((r + _samples_per_cc) / (_samples_per_cc << 1)) *
+           (_samples_per_cc << 1); // multiple of color clock, word align
+}
+
+#define NTSC_COLOR_CLOCKS_PER_SCANLINE                                                             \
+    228 // really 227.5 for NTSC but want to avoid half phase fiddling for now
+#define NTSC_FREQUENCY                (315000000.0 / 88)
+#define NTSC_LINES                    262
+
+#define PAL_COLOR_CLOCKS_PER_SCANLINE 284 // really 283.75 ?
+#define PAL_FREQUENCY                 4433618.75
+#define PAL_LINES                     312
+
+void pal_init();
+
+void video_init(int ntsc)
+{
+    _framebuffer = cv_framebuffer;
+    _samples_per_cc = 4;
+
+    if (ntsc)
+    {
+        _palette = nes_4_phase;
+        _sample_rate = 315.0 / 88 * _samples_per_cc; // DAC rate
+        _line_width = NTSC_COLOR_CLOCKS_PER_SCANLINE * _samples_per_cc;
+        _line_count = NTSC_LINES;
+        _hsync_long = usec(63.555 - 4.7);
+        _active_start = usec(_samples_per_cc == 4 ? 10 : 10.5);
+        _hsync = usec(4.7);
+        _pal_ = 0;
+    }
+    else
+    {
+        pal_init();
+        _pal_ = 1;
+    }
+
+    _active_lines = 240;
+    video_init_hw(_line_width, _samples_per_cc); // init the hardware
+}
+
+//===================================================================================================
+//===================================================================================================
+// PAL
+
+void pal_init()
+{
+    _palette = nes_yuv_4_phase_pal;
+    int cc_width = 4;
+    _sample_rate = PAL_FREQUENCY * cc_width / 1000000.0; // DAC rate in mhz
+    _line_width = PAL_COLOR_CLOCKS_PER_SCANLINE * cc_width;
+    _line_count = PAL_LINES;
+    _hsync_short = usec(2);
+    _hsync_long = usec(30);
+    _hsync = usec(4.7);
+    _burst_start = usec(5.6);
+    _burst_width = (int)(10 * cc_width + 4) & 0xFFFE;
+    _active_start = usec(10.4);
+
+    // make colorburst tables for even and odd lines
+    _burst0 = new int16_t[_burst_width];
+    _burst1 = new int16_t[_burst_width];
+    float phase = 2 * M_PI / 2;
+    for (int i = 0; i < _burst_width; i++)
+    {
+        _burst0[i] = BLANKING_LEVEL + sin(phase + 3 * M_PI / 4) * BLANKING_LEVEL / 1.5;
+        _burst1[i] = BLANKING_LEVEL + sin(phase - 3 * M_PI / 4) * BLANKING_LEVEL / 1.5;
+        phase += 2 * M_PI / cc_width;
+    }
+}
+
+void IRAM_ATTR blit_pal(uint8_t* src, uint16_t* dst)
+{
+    uint32_t c, color;
+    bool even = _line_counter & 1;
+    const uint32_t* p = even ? _palette : _palette + 256;
+    int left = 0;
+    int right = 256;
+    uint8_t mask = 0xFF;
+    uint8_t c0, c1, c2, c3, c4;
+    uint8_t y1, y2, y3;
+
+    // case EMU_NES:
+    // 192 of 288 color clocks wide: roughly correct aspect ratio
+    mask = 0x3F;
+    if (!even) p = _palette + 64;
+    dst += 88;
+
+    // 4 pixels over 3 color clocks, 12 samples
+    // do the blitting
+    for (int i = left; i < right; i += 4)
+    {
+        c = *((uint32_t*)(src + i));
+        color = p[c & mask];
+        dst[0 ^ 1] = P0;
+        dst[1 ^ 1] = P1;
+        dst[2 ^ 1] = P2;
+        color = p[(c >> 8) & mask];
+        dst[3 ^ 1] = P3;
+        dst[4 ^ 1] = P0;
+        dst[5 ^ 1] = P1;
+        color = p[(c >> 16) & mask];
+        dst[6 ^ 1] = P2;
+        dst[7 ^ 1] = P3;
+        dst[8 ^ 1] = P0;
+        color = p[(c >> 24) & mask];
+        dst[9 ^ 1] = P1;
+        dst[10 ^ 1] = P2;
+        dst[11 ^ 1] = P3;
+        dst += 12;
+    }
+}
+
+void IRAM_ATTR burst_pal(uint16_t* line)
+{
+    line += _burst_start;
+    int16_t* b = (_line_counter & 1) ? _burst0 : _burst1;
+    for (int i = 0; i < _burst_width; i += 2)
+    {
+        line[i ^ 1] = b[i];
+        line[(i + 1) ^ 1] = b[i + 1];
+    }
+}
+
+//===================================================================================================
+//===================================================================================================
+// ntsc tables
+// AA AA                // 2 pixels, 1 color clock - atari
+// AA AB BB             // 3 pixels, 2 color clocks - nes
+// AAA ABB BBC CCC      // 4 pixels, 3 color clocks - sms
+
+// cc == 3 gives 684 samples per line, 3 samples per cc, 3 pixels for 2 cc
+// cc == 4 gives 912 samples per line, 4 samples per cc, 2 pixels per cc
+
+// draw a line of game in NTSC
+void IRAM_ATTR blit(uint8_t* src, uint16_t* dst)
+{
+    uint32_t* d = (uint32_t*)dst;
+    const uint32_t* p = _palette;
+    uint32_t color, c;
+    uint32_t mask = 0xFF;
+    int i;
+
+    if (_pal_)
+    {
+        blit_pal(src, dst);
+        return;
+    }
+
+    // case EMU_NES:
+    mask = 0x3F;
+    // AAA ABB BBC CCC
+    // 4 pixels, 3 color clocks, 4 samples per cc
+    // each pixel gets 3 samples, 192 color clocks wide
+    for (i = 0; i < 256; i += 4)
+    {
+        c = *((uint32_t*)(src + i));
+        color = p[c & mask];
+        dst[0 ^ 1] = P0;
+        dst[1 ^ 1] = P1;
+        dst[2 ^ 1] = P2;
+        color = p[(c >> 8) & mask];
+        dst[3 ^ 1] = P3;
+        dst[4 ^ 1] = P0;
+        dst[5 ^ 1] = P1;
+        color = p[(c >> 16) & mask];
+        dst[6 ^ 1] = P2;
+        dst[7 ^ 1] = P3;
+        dst[8 ^ 1] = P0;
+        color = p[(c >> 24) & mask];
+        dst[9 ^ 1] = P1;
+        dst[10 ^ 1] = P2;
+        dst[11 ^ 1] = P3;
+        dst += 12;
+    }
+}
+
+void IRAM_ATTR burst(uint16_t* line)
+{
+    if (_pal_)
+    {
+        burst_pal(line);
+        return;
+    }
+
+    int i, phase;
+    switch (_samples_per_cc)
+    {
+    case 4:
+        // 4 samples per color clock
+        for (i = _hsync; i < _hsync + (4 * 10); i += 4)
+        {
+            line[i + 1] = BLANKING_LEVEL;
+            line[i + 0] = BLANKING_LEVEL + BLANKING_LEVEL / 2;
+            line[i + 3] = BLANKING_LEVEL;
+            line[i + 2] = BLANKING_LEVEL - BLANKING_LEVEL / 2;
+        }
+        break;
+    case 3:
+        // 3 samples per color clock
+        phase = 0.866025 * BLANKING_LEVEL / 2;
+        for (i = _hsync; i < _hsync + (3 * 10); i += 6)
+        {
+            line[i + 1] = BLANKING_LEVEL;
+            line[i + 0] = BLANKING_LEVEL + phase;
+            line[i + 3] = BLANKING_LEVEL - phase;
+            line[i + 2] = BLANKING_LEVEL;
+            line[i + 5] = BLANKING_LEVEL + phase;
+            line[i + 4] = BLANKING_LEVEL - phase;
+        }
+        break;
+    }
+}
+
+void IRAM_ATTR sync(uint16_t* line, int syncwidth)
+{
+    for (int i = 0; i < syncwidth; i++) line[i] = SYNC_LEVEL;
+}
+
+void IRAM_ATTR blanking(uint16_t* line, bool vbl)
+{
+    int syncwidth = vbl ? _hsync_long : _hsync;
+    sync(line, syncwidth);
+    for (int i = syncwidth; i < _line_width; i++) line[i] = BLANKING_LEVEL;
+    if (!vbl) burst(line); // no burst during vbl
+}
+
+// Fancy pal non-interlace
+// http://martin.hinner.info/vga/pal.html
+void IRAM_ATTR pal_sync2(uint16_t* line, int width, int swidth)
+{
+    swidth = swidth ? _hsync_long : _hsync_short;
+    int i;
+    for (i = 0; i < swidth; i++) line[i] = SYNC_LEVEL;
+    for (; i < width; i++) line[i] = BLANKING_LEVEL;
+}
+
+uint8_t DRAM_ATTR _sync_type[8] = { 0, 0, 0, 3, 3, 2, 0, 0 };
+void IRAM_ATTR pal_sync(uint16_t* line, int i)
+{
+    uint8_t t = _sync_type[i - 304];
+    pal_sync2(line, _line_width / 2, t & 2);
+    pal_sync2(line + _line_width / 2, _line_width / 2, t & 1);
+}
+
+//  audio is buffered as 6 bit unsigned samples
+uint8_t _audio_buffer[128];
+uint32_t _audio_r = 0;
+uint32_t _audio_w = 0;
+void audio_write_16(const int16_t* s, int len, int channels)
+{
+    int b;
+    while (len--)
+    {
+        if (_audio_w == (_audio_r + sizeof(_audio_buffer))) break;
+        if (channels == 2)
+        {
+            b = (s[0] + s[1]) >> 9;
+            s += 2;
+        }
+        else b = *s++ >> 8;
+        if (b < -32) b = -32;
+        if (b > 31) b = 31;
+        _audio_buffer[_audio_w++ & (sizeof(_audio_buffer) - 1)] = b + 32;
+    }
+}
+
+// Wait for blanking before starting drawing
+// avoids tearing in our unsynchonized world
+void video_sync()
+{
+    int n = 0;
+    if (_pal_)
+    {
+        if (_line_counter < _active_lines) n = (_active_lines - _line_counter) * 1000 / 15600;
+    }
+    else
+    {
+        if (_line_counter < _active_lines) n = (_active_lines - _line_counter) * 1000 / 15720;
+    }
+    vTaskDelay(n + 1);
+}
+
+void IRAM_ATTR video_isr(volatile void* vbuf)
+{
+    if (!_framebuffer) return;
+
+    // uint8_t s =
+    //     _audio_r < _audio_w ? _audio_buffer[_audio_r++ & (sizeof(_audio_buffer) - 1)] : 0x20;
+    // audio_sample(s);
+    // audio_sample(_sin64[_x++ & 0x3F]);
+
+    int i = _line_counter++;
+    uint16_t* buf = (uint16_t*)vbuf;
+    if (_pal_)
+    {
+        // pal
+        if (i < 32)
+        {
+            blanking(buf, false); // pre render/black 0-32
+        }
+        else if (i < _active_lines + 32)
+        { // active video 32-272
+            sync(buf, _hsync);
+            burst(buf);
+            blit(_framebuffer + ((i - 32) * 256), buf + _active_start);
+        }
+        else if (i < 304)
+        {                // post render/black 272-304
+            if (i < 274) // slight optimization here, once you have 2 blanking buffers
+                blanking(buf, false);
+        }
+        else
+        {
+            pal_sync(buf, i); // 8 lines of sync 304-312
+        }
+    }
+    else
+    {
+        // ntsc
+        if (i < _active_lines)
+        { // active video
+            sync(buf, _hsync);
+            burst(buf);
+            blit(_framebuffer + (i * 256), buf + _active_start);
+        }
+        else if (i < (_active_lines + 5))
+        { // post render/black
+            blanking(buf, false);
+        }
+        else if (i < (_active_lines + 8))
+        { // vsync
+            blanking(buf, true);
+        }
+        else
+        { // pre render/black
+            blanking(buf, false);
+        }
+    }
+
+    if (_line_counter == _line_count)
+    {
+        _line_counter = 0; // frame is done
+        _frame_counter++;
+    }
+}
+
+// Composite UI
+// Constant: font8x8_basic
+// Contains an 8x8 font map for unicode points U+0000 - U+007F (basic latin)
+static constexpr char font8x8_basic[128][8] = {
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0000 (nul)
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0001
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0002
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0003
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0004
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0005
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0006
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0007
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0008
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0009
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+000A
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+000B
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+000C
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+000D
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+000E
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+000F
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0010
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0011
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0012
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0013
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0014
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0015
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0016
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0017
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0018
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0019
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+001A
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+001B
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+001C
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+001D
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+001E
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+001F
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0020 (space)
+    { 0x18, 0x3C, 0x3C, 0x18, 0x18, 0x00, 0x18, 0x00 }, // U+0021 (!)
+    { 0x36, 0x36, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0022 (")
+    { 0x36, 0x36, 0x7F, 0x36, 0x7F, 0x36, 0x36, 0x00 }, // U+0023 (#)
+    { 0x0C, 0x3E, 0x03, 0x1E, 0x30, 0x1F, 0x0C, 0x00 }, // U+0024 ($)
+    { 0x00, 0x63, 0x33, 0x18, 0x0C, 0x66, 0x63, 0x00 }, // U+0025 (%)
+    { 0x1C, 0x36, 0x1C, 0x6E, 0x3B, 0x33, 0x6E, 0x00 }, // U+0026 (&)
+    { 0x06, 0x06, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0027 (')
+    { 0x18, 0x0C, 0x06, 0x06, 0x06, 0x0C, 0x18, 0x00 }, // U+0028 (()
+    { 0x06, 0x0C, 0x18, 0x18, 0x18, 0x0C, 0x06, 0x00 }, // U+0029 ())
+    { 0x00, 0x66, 0x3C, 0xFF, 0x3C, 0x66, 0x00, 0x00 }, // U+002A (*)
+    { 0x00, 0x0C, 0x0C, 0x3F, 0x0C, 0x0C, 0x00, 0x00 }, // U+002B (+)
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C, 0x06 }, // U+002C (,)
+    { 0x00, 0x00, 0x00, 0x3F, 0x00, 0x00, 0x00, 0x00 }, // U+002D (-)
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x0C, 0x0C, 0x00 }, // U+002E (.)
+    { 0x60, 0x30, 0x18, 0x0C, 0x06, 0x03, 0x01, 0x00 }, // U+002F (/)
+    { 0x3E, 0x63, 0x73, 0x7B, 0x6F, 0x67, 0x3E, 0x00 }, // U+0030 (0)
+    { 0x0C, 0x0E, 0x0C, 0x0C, 0x0C, 0x0C, 0x3F, 0x00 }, // U+0031 (1)
+    { 0x1E, 0x33, 0x30, 0x1C, 0x06, 0x33, 0x3F, 0x00 }, // U+0032 (2)
+    { 0x1E, 0x33, 0x30, 0x1C, 0x30, 0x33, 0x1E, 0x00 }, // U+0033 (3)
+    { 0x38, 0x3C, 0x36, 0x33, 0x7F, 0x30, 0x78, 0x00 }, // U+0034 (4)
+    { 0x3F, 0x03, 0x1F, 0x30, 0x30, 0x33, 0x1E, 0x00 }, // U+0035 (5)
+    { 0x1C, 0x06, 0x03, 0x1F, 0x33, 0x33, 0x1E, 0x00 }, // U+0036 (6)
+    { 0x3F, 0x33, 0x30, 0x18, 0x0C, 0x0C, 0x0C, 0x00 }, // U+0037 (7)
+    { 0x1E, 0x33, 0x33, 0x1E, 0x33, 0x33, 0x1E, 0x00 }, // U+0038 (8)
+    { 0x1E, 0x33, 0x33, 0x3E, 0x30, 0x18, 0x0E, 0x00 }, // U+0039 (9)
+    { 0x00, 0x0C, 0x0C, 0x00, 0x00, 0x0C, 0x0C, 0x00 }, // U+003A (:)
+    { 0x00, 0x0C, 0x0C, 0x00, 0x00, 0x0C, 0x0C, 0x06 }, // U+003B (;)
+    { 0x18, 0x0C, 0x06, 0x03, 0x06, 0x0C, 0x18, 0x00 }, // U+003C (<)
+    { 0x00, 0x00, 0x3F, 0x00, 0x00, 0x3F, 0x00, 0x00 }, // U+003D (=)
+    { 0x06, 0x0C, 0x18, 0x30, 0x18, 0x0C, 0x06, 0x00 }, // U+003E (>)
+    { 0x1E, 0x33, 0x30, 0x18, 0x0C, 0x00, 0x0C, 0x00 }, // U+003F (?)
+    { 0x3E, 0x63, 0x7B, 0x7B, 0x7B, 0x03, 0x1E, 0x00 }, // U+0040 (@)
+    { 0x0C, 0x1E, 0x33, 0x33, 0x3F, 0x33, 0x33, 0x00 }, // U+0041 (A)
+    { 0x3F, 0x66, 0x66, 0x3E, 0x66, 0x66, 0x3F, 0x00 }, // U+0042 (B)
+    { 0x3C, 0x66, 0x03, 0x03, 0x03, 0x66, 0x3C, 0x00 }, // U+0043 (C)
+    { 0x1F, 0x36, 0x66, 0x66, 0x66, 0x36, 0x1F, 0x00 }, // U+0044 (D)
+    { 0x7F, 0x46, 0x16, 0x1E, 0x16, 0x46, 0x7F, 0x00 }, // U+0045 (E)
+    { 0x7F, 0x46, 0x16, 0x1E, 0x16, 0x06, 0x0F, 0x00 }, // U+0046 (F)
+    { 0x3C, 0x66, 0x03, 0x03, 0x73, 0x66, 0x7C, 0x00 }, // U+0047 (G)
+    { 0x33, 0x33, 0x33, 0x3F, 0x33, 0x33, 0x33, 0x00 }, // U+0048 (H)
+    { 0x1E, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x1E, 0x00 }, // U+0049 (I)
+    { 0x78, 0x30, 0x30, 0x30, 0x33, 0x33, 0x1E, 0x00 }, // U+004A (J)
+    { 0x67, 0x66, 0x36, 0x1E, 0x36, 0x66, 0x67, 0x00 }, // U+004B (K)
+    { 0x0F, 0x06, 0x06, 0x06, 0x46, 0x66, 0x7F, 0x00 }, // U+004C (L)
+    { 0x63, 0x77, 0x7F, 0x7F, 0x6B, 0x63, 0x63, 0x00 }, // U+004D (M)
+    { 0x63, 0x67, 0x6F, 0x7B, 0x73, 0x63, 0x63, 0x00 }, // U+004E (N)
+    { 0x1C, 0x36, 0x63, 0x63, 0x63, 0x36, 0x1C, 0x00 }, // U+004F (O)
+    { 0x3F, 0x66, 0x66, 0x3E, 0x06, 0x06, 0x0F, 0x00 }, // U+0050 (P)
+    { 0x1E, 0x33, 0x33, 0x33, 0x3B, 0x1E, 0x38, 0x00 }, // U+0051 (Q)
+    { 0x3F, 0x66, 0x66, 0x3E, 0x36, 0x66, 0x67, 0x00 }, // U+0052 (R)
+    { 0x1E, 0x33, 0x07, 0x0E, 0x38, 0x33, 0x1E, 0x00 }, // U+0053 (S)
+    { 0x3F, 0x2D, 0x0C, 0x0C, 0x0C, 0x0C, 0x1E, 0x00 }, // U+0054 (T)
+    { 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x3F, 0x00 }, // U+0055 (U)
+    { 0x33, 0x33, 0x33, 0x33, 0x33, 0x1E, 0x0C, 0x00 }, // U+0056 (V)
+    { 0x63, 0x63, 0x63, 0x6B, 0x7F, 0x77, 0x63, 0x00 }, // U+0057 (W)
+    { 0x63, 0x63, 0x36, 0x1C, 0x1C, 0x36, 0x63, 0x00 }, // U+0058 (X)
+    { 0x33, 0x33, 0x33, 0x1E, 0x0C, 0x0C, 0x1E, 0x00 }, // U+0059 (Y)
+    { 0x7F, 0x63, 0x31, 0x18, 0x4C, 0x66, 0x7F, 0x00 }, // U+005A (Z)
+    { 0x1E, 0x06, 0x06, 0x06, 0x06, 0x06, 0x1E, 0x00 }, // U+005B ([)
+    { 0x03, 0x06, 0x0C, 0x18, 0x30, 0x60, 0x40, 0x00 }, // U+005C (\)
+    { 0x1E, 0x18, 0x18, 0x18, 0x18, 0x18, 0x1E, 0x00 }, // U+005D (])
+    { 0x08, 0x1C, 0x36, 0x63, 0x00, 0x00, 0x00, 0x00 }, // U+005E (^)
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xFF }, // U+005F (_)
+    { 0x0C, 0x0C, 0x18, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+0060 (`)
+    { 0x00, 0x00, 0x1E, 0x30, 0x3E, 0x33, 0x6E, 0x00 }, // U+0061 (a)
+    { 0x07, 0x06, 0x06, 0x3E, 0x66, 0x66, 0x3B, 0x00 }, // U+0062 (b)
+    { 0x00, 0x00, 0x1E, 0x33, 0x03, 0x33, 0x1E, 0x00 }, // U+0063 (c)
+    { 0x38, 0x30, 0x30, 0x3e, 0x33, 0x33, 0x6E, 0x00 }, // U+0064 (d)
+    { 0x00, 0x00, 0x1E, 0x33, 0x3f, 0x03, 0x1E, 0x00 }, // U+0065 (e)
+    { 0x1C, 0x36, 0x06, 0x0f, 0x06, 0x06, 0x0F, 0x00 }, // U+0066 (f)
+    { 0x00, 0x00, 0x6E, 0x33, 0x33, 0x3E, 0x30, 0x1F }, // U+0067 (g)
+    { 0x07, 0x06, 0x36, 0x6E, 0x66, 0x66, 0x67, 0x00 }, // U+0068 (h)
+    { 0x0C, 0x00, 0x0E, 0x0C, 0x0C, 0x0C, 0x1E, 0x00 }, // U+0069 (i)
+    { 0x30, 0x00, 0x30, 0x30, 0x30, 0x33, 0x33, 0x1E }, // U+006A (j)
+    { 0x07, 0x06, 0x66, 0x36, 0x1E, 0x36, 0x67, 0x00 }, // U+006B (k)
+    { 0x0E, 0x0C, 0x0C, 0x0C, 0x0C, 0x0C, 0x1E, 0x00 }, // U+006C (l)
+    { 0x00, 0x00, 0x33, 0x7F, 0x7F, 0x6B, 0x63, 0x00 }, // U+006D (m)
+    { 0x00, 0x00, 0x1F, 0x33, 0x33, 0x33, 0x33, 0x00 }, // U+006E (n)
+    { 0x00, 0x00, 0x1E, 0x33, 0x33, 0x33, 0x1E, 0x00 }, // U+006F (o)
+    { 0x00, 0x00, 0x3B, 0x66, 0x66, 0x3E, 0x06, 0x0F }, // U+0070 (p)
+    { 0x00, 0x00, 0x6E, 0x33, 0x33, 0x3E, 0x30, 0x78 }, // U+0071 (q)
+    { 0x00, 0x00, 0x3B, 0x6E, 0x66, 0x06, 0x0F, 0x00 }, // U+0072 (r)
+    { 0x00, 0x00, 0x3E, 0x03, 0x1E, 0x30, 0x1F, 0x00 }, // U+0073 (s)
+    { 0x08, 0x0C, 0x3E, 0x0C, 0x0C, 0x2C, 0x18, 0x00 }, // U+0074 (t)
+    { 0x00, 0x00, 0x33, 0x33, 0x33, 0x33, 0x6E, 0x00 }, // U+0075 (u)
+    { 0x00, 0x00, 0x33, 0x33, 0x33, 0x1E, 0x0C, 0x00 }, // U+0076 (v)
+    { 0x00, 0x00, 0x63, 0x6B, 0x7F, 0x7F, 0x36, 0x00 }, // U+0077 (w)
+    { 0x00, 0x00, 0x63, 0x36, 0x1C, 0x36, 0x63, 0x00 }, // U+0078 (x)
+    { 0x00, 0x00, 0x33, 0x33, 0x33, 0x3E, 0x30, 0x1F }, // U+0079 (y)
+    { 0x00, 0x00, 0x3F, 0x19, 0x0C, 0x26, 0x3F, 0x00 }, // U+007A (z)
+    { 0x38, 0x0C, 0x0C, 0x07, 0x0C, 0x0C, 0x38, 0x00 }, // U+007B ({)
+    { 0x18, 0x18, 0x18, 0x00, 0x18, 0x18, 0x18, 0x00 }, // U+007C (|)
+    { 0x07, 0x0C, 0x0C, 0x38, 0x0C, 0x0C, 0x07, 0x00 }, // U+007D (})
+    { 0x6E, 0x3B, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }, // U+007E (~)
+    { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }  // U+007F
+};
+// NES palette indices for UI colors
+#define CV_BLACK     0x0F
+#define CV_WHITE     0x30
+#define CV_GRAY      0x00
+#define CV_RED       0x16
+#define CV_GREEN     0x1A
+#define CV_DARK_BLUE 0x12
+#define CV_DARK_GRAY 0x31
+
+inline void cv_fill(uint8_t color)
+{
+    if (color >= 64) return;
+    memset(_framebuffer, color, 240 * 256);
+}
+
+inline void cv_draw_pixel(int x, int y, uint8_t color)
+{
+    if (x < 0 || x >= 256 || y < 0 || y >= 240) return;
+    if (color >= 64) return;
+    _framebuffer[y * 256 + x] = color;
+}
+
+inline void cv_draw_rect(int x, int y, int w, int h, uint8_t color)
+{
+    for (int row = y; row < y + h; row++)
+        for (int col = x; col < x + w; col++) cv_draw_pixel(col, row, color);
+}
+
+inline void cv_draw_char(int x, int y, char c, uint8_t color)
+{
+    if (c < 0 || c > 127) return;
+    const uint8_t* glyph = (const uint8_t*)font8x8_basic[(uint8_t)c];
+    for (int row = 0; row < 8; row++)
+        for (int col = 0; col < 8; col++)
+            if (glyph[row] & (1 << col)) cv_draw_pixel(x + col, y + row, color);
+}
+
+inline void cv_draw_string(const char* str, int x, int y, uint8_t color)
+{
+    while (*str)
+    {
+        cv_draw_char(x, y, *str++, color);
+        x += 8;
+    }
+}
+
+inline constexpr int cv_text_width(const char* str)
+{
+    if (!str) return 0;
+
+    int width = 0;
+
+    while (*str++) width += 8; // 8 pixels glyph
+
+    // Remove trailing spacing after last character
+    if (width > 0) width -= 1;
+
+    return width;
+}
+
+inline void cv_getNesFiles(std::vector<std::string>& files)
+{
+    File root = SD.open("/");
+    while (true)
+    {
+        File file = root.openNextFile();
+        if (!file) break;
+        if (!file.isDirectory())
+        {
+            std::string filename = file.name();
+            if (filename.rfind(".nes") == filename.size() - 4) files.push_back(filename);
+        }
+
+        file.close();
+    }
+    root.close();
+}
+
+inline void cv_drawFileList(int size, int max_items, int selected, int scroll_offset,
+                            std::vector<std::string>& files)
+{
+    for (int i = 0; i < max_items; i++)
+    {
+        int item = i + scroll_offset;
+        if (item >= size) break;
+
+        std::string file = files[item];
+        int maxWidth = screen_width - 28;
+        while (cv_text_width(file.c_str()) > maxWidth) { file.pop_back(); }
+        if (file.size() < files[item].size()) { file.replace(file.size() - 3, 3, "..."); }
+
+        const char* filename = file.c_str();
+        int y = i * 10 + 32;
+        if (item == selected) cv_draw_string(filename, 14, y, CV_GREEN);
+        else cv_draw_string(filename, 14, y, CV_WHITE);
+    }
+}
+
+Cartridge* cv_selectGame()
+{
+    cv_fill(CV_BLACK);
+
+    int selected = 0;
+    int scroll_offset = 0;
+    std::vector<std::string> files;
+    static constexpr int max_items = (screen_height - 30) / 10;
+
+    cv_getNesFiles(files);
+
+    const int size = files.size();
+    cv_drawFileList(size, max_items, selected, scroll_offset, files);
+
+    unsigned int last_input_time = 0;
+    while (true)
+    {
+        static constexpr unsigned int delay = 250;
+        unsigned int now = millis();
+
+        if (now - last_input_time > delay)
+        {
+            if (isDownPressed(CONTROLLER::Up))
+            {
+                selected--;
+                if (selected < 0)
+                {
+                    selected = (size - 1);
+                    scroll_offset = selected - max_items + 1;
+                }
+                else if (selected < scroll_offset) scroll_offset = selected;
+                if (scroll_offset < 0) scroll_offset = 0;
+                if (scroll_offset > size - 1) scroll_offset = size - 1;
+                cv_draw_rect(10, 32, screen_width - 20, screen_height - 16, CV_BLACK);
+                cv_drawFileList(size, max_items, selected, scroll_offset, files);
+                last_input_time = now;
+            }
+
+            if (isDownPressed(CONTROLLER::Down))
+            {
+                selected++;
+                if (selected > (size - 1))
+                {
+                    selected = 0;
+                    scroll_offset = selected;
+                }
+                else if (selected >= scroll_offset + max_items)
+                    scroll_offset = selected - max_items + 1;
+                if (scroll_offset < 0) scroll_offset = 0;
+                if (scroll_offset > size - 1) scroll_offset = size - 1;
+                cv_draw_rect(10, 32, screen_width - 20, screen_height - 16, CV_BLACK);
+                cv_drawFileList(size, max_items, selected, scroll_offset, files);
+                last_input_time = now;
+            }
+
+            if (isDownPressed(CONTROLLER::Left))
+            {
+                int screen_pos = selected - scroll_offset;
+                selected -= max_items;
+                if (selected < 0) selected = 0;
+                scroll_offset = selected - screen_pos;
+                if (scroll_offset < 0) scroll_offset = 0;
+                cv_draw_rect(10, 32, screen_width - 20, screen_height - 16, CV_BLACK);
+                cv_drawFileList(size, max_items, selected, scroll_offset, files);
+                last_input_time = now;
+            }
+
+            if (isDownPressed(CONTROLLER::Right))
+            {
+                int screen_pos = selected - scroll_offset;
+                selected += max_items;
+                if (selected > size - 1) selected = size - 1;
+                scroll_offset = selected - screen_pos;
+                if (scroll_offset < 0) scroll_offset = 0;
+                if (scroll_offset > size - 1) scroll_offset = size - 1;
+                cv_draw_rect(10, 32, screen_width - 20, screen_height - 16, CV_BLACK);
+                cv_drawFileList(size, max_items, selected, scroll_offset, files);
+                last_input_time = now;
+            }
+        }
+
+        if (isDownPressed(CONTROLLER::A) && (selected >= 0 && selected < size))
+        {
+            std::string game = "/" + files[selected];
+            std::vector<std::string>().swap(files);
+            return new Cartridge(game.c_str(), ROMBackend::FLASH);
+        }
+    }
+}
+
+bool cv_paused = false;
+void cv_pauseMenu(Bus* nes)
+{
+    int prev_select = 0;
+    int select = 0;
+    static constexpr int window_w = 160;
+    static constexpr int window_h = 96;
+    static constexpr int window_x = (screen_width - window_w) / 2;
+    static constexpr int window_y = (screen_height - window_h) / 2;
+    static constexpr char* title = "PAUSE MENU";
+    static constexpr int title_x = window_x + ((window_w - cv_text_width(title)) / 2);
+    static constexpr int title_y = window_y + 8;
+
+    enum ItemSelect : uint8_t
+    {
+        Resume,
+        Reset,
+        QuickSaveState,
+        QuickLoadState,
+        SaveAndQuit
+    };
+    static constexpr const char* items[] = { "Resume", "Reset", "Quick Save State",
+                                             "Quick Load State", "Save and Quit" };
+    static constexpr int num_items = sizeof(items) / sizeof(items[0]);
+    static constexpr int item_height = 12;
+    static constexpr int text_height = 8;
+    static constexpr int item_spacing = 2;
+    static constexpr int items_start_y = window_y + 24;
+    static constexpr int items_y[] = {
+        items_start_y + (item_height + item_spacing) * 0,
+        items_start_y + (item_height + item_spacing) * 1,
+        items_start_y + (item_height + item_spacing) * 2,
+        items_start_y + (item_height + item_spacing) * 3,
+        items_start_y + (item_height + item_spacing) * 4,
+    };
+
+    // Draw pause window
+    cv_draw_rect(window_x - 2, window_y - 2, window_w + 4, window_h + 4, CV_GRAY);
+    cv_draw_rect(window_x, window_y, window_w, window_h, CV_DARK_BLUE);
+    cv_draw_string(title, title_x, title_y, CV_WHITE);
+
+    // Draw items
+    for (int i = 0; i < num_items; i++)
+    {
+        int y = items_y[i] + item_spacing;
+        cv_draw_string(items[i], window_x + 12, y, CV_WHITE);
+    }
+    cv_draw_rect(window_x + 10, items_y[select], window_w - 20, item_height, CV_WHITE);
+    cv_draw_string(items[select], window_x + 12, items_y[select] + item_spacing, CV_DARK_BLUE);
+
+    static constexpr int initial_delay = 500;
+    int last_input_time = millis() + initial_delay;
+    while (true)
+    {
+        static constexpr int delay = 250;
+        int now = millis();
+        if (now - last_input_time > delay)
+        {
+            if (isDownPressed(CONTROLLER::Up))
+            {
+                select--;
+                if (select < 0) select = (num_items - 1);
+                last_input_time = now;
+            }
+
+            if (isDownPressed(CONTROLLER::Down))
+            {
+                select++;
+                if (select > (num_items - 1)) select = 0;
+                last_input_time = now;
+            }
+
+            if (isDownPressed(CONTROLLER::A))
+            {
+                switch (select)
+                {
+                case Resume: cv_paused = false; return;
+
+                case Reset:
+                    nes->reset();
+                    cv_paused = false;
+                    return;
+
+                case QuickSaveState:
+                    nes->saveState();
+                    cv_paused = false;
+                    return;
+
+                case QuickLoadState:
+                    nes->loadState();
+                    cv_paused = false;
+                    return;
+
+                case SaveAndQuit: ESP.restart(); return;
+                default: break;
+                }
+            }
+        }
+
+        // Update Selection
+        if (prev_select != select)
+        {
+            int y;
+            // Redraw old selection
+            cv_draw_rect(window_x + 10, items_y[prev_select], window_w - 19, item_height,
+                         CV_DARK_BLUE);
+            y = items_y[prev_select] + item_spacing;
+            cv_draw_string(items[prev_select], window_x + 12, y, CV_WHITE);
+
+            // Draw new selection
+            cv_draw_rect(window_x + 10, items_y[select], window_w - 19, item_height, CV_WHITE);
+            y = items_y[select] + item_spacing;
+            cv_draw_string(items[select], window_x + 12, y, CV_DARK_BLUE);
+        }
+
+        prev_select = select;
+    }
+}
+
+#endif

--- a/src/core/apu2A03.cpp
+++ b/src/core/apu2A03.cpp
@@ -3,7 +3,6 @@
 #include "cpu6502.h"
 
 #ifdef COMPOSITE_VIDEO
-extern uint8_t _audio_buffer[1024];
 void cv_audio_write_16(const uint16_t* s, int len, int channels);
 bool cv_audio_buffer_full(int buffer_size);
 #endif

--- a/src/core/apu2A03.cpp
+++ b/src/core/apu2A03.cpp
@@ -2,6 +2,13 @@
 #include "bus.h"
 #include "cpu6502.h"
 
+#ifdef COMPOSITE_VIDEO
+extern uint8_t _audio_buffer[512];
+extern uint32_t _audio_r;
+extern uint32_t _audio_w;
+void audio_write_16(const int16_t* s, int len, int channels);
+#endif
+
 DMA_ATTR uint16_t Apu2A03::audio_buffer[AUDIO_BUFFER_SIZE * 2];
 
 Apu2A03::Apu2A03()
@@ -377,10 +384,19 @@ inline void Apu2A03::generateSample()
     if (buffer_index >= AUDIO_BUFFER_SIZE)
     {
         buffer_index = 0;
-
-        static size_t dummy;
-        i2s_write(I2S_NUM_0, audio_buffer, sizeof(audio_buffer), &dummy, portMAX_DELAY);
+        writeBuffer();
     }
+}
+
+inline void Apu2A03::writeBuffer()
+{
+#ifndef COMPOSITE_VIDEO
+    static size_t dummy;
+    i2s_write(I2S_NUM_0, audio_buffer, sizeof(audio_buffer), &dummy, portMAX_DELAY);
+#else
+    while ((_audio_w - _audio_r) + AUDIO_BUFFER_SIZE > sizeof(_audio_buffer)) vTaskDelay(1);
+    audio_write_16((const int16_t*)audio_buffer, AUDIO_BUFFER_SIZE, 2);
+#endif
 }
 
 inline void Apu2A03::pulseChannelClock(sequencerUnit& seq, bool enable)

--- a/src/core/apu2A03.cpp
+++ b/src/core/apu2A03.cpp
@@ -394,7 +394,7 @@ inline void Apu2A03::writeBuffer()
     i2s_write(I2S_NUM_0, audio_buffer, sizeof(audio_buffer), &dummy, portMAX_DELAY);
 #else
     while (cv_audio_buffer_full(AUDIO_BUFFER_SIZE)) vTaskDelay(1);
-    audio_write_16((const uint16_t*)audio_buffer, AUDIO_BUFFER_SIZE, 2);
+    cv_audio_write_16((const uint16_t*)audio_buffer, AUDIO_BUFFER_SIZE, 2);
 #endif
 }
 

--- a/src/core/apu2A03.cpp
+++ b/src/core/apu2A03.cpp
@@ -6,7 +6,7 @@
 extern uint8_t _audio_buffer[512];
 extern uint32_t _audio_r;
 extern uint32_t _audio_w;
-void audio_write_16(const int16_t* s, int len, int channels);
+void audio_write_16(const uint16_t* s, int len, int channels);
 #endif
 
 DMA_ATTR uint16_t Apu2A03::audio_buffer[AUDIO_BUFFER_SIZE * 2];
@@ -395,7 +395,7 @@ inline void Apu2A03::writeBuffer()
     i2s_write(I2S_NUM_0, audio_buffer, sizeof(audio_buffer), &dummy, portMAX_DELAY);
 #else
     while ((_audio_w - _audio_r) + AUDIO_BUFFER_SIZE > sizeof(_audio_buffer)) vTaskDelay(1);
-    audio_write_16((const int16_t*)audio_buffer, AUDIO_BUFFER_SIZE, 2);
+    audio_write_16((const uint16_t*)audio_buffer, AUDIO_BUFFER_SIZE, 2);
 #endif
 }
 

--- a/src/core/apu2A03.cpp
+++ b/src/core/apu2A03.cpp
@@ -3,10 +3,9 @@
 #include "cpu6502.h"
 
 #ifdef COMPOSITE_VIDEO
-extern uint8_t _audio_buffer[512];
-extern uint32_t _audio_r;
-extern uint32_t _audio_w;
-void audio_write_16(const uint16_t* s, int len, int channels);
+extern uint8_t _audio_buffer[1024];
+void cv_audio_write_16(const uint16_t* s, int len, int channels);
+bool cv_audio_buffer_full(int buffer_size);
 #endif
 
 DMA_ATTR uint16_t Apu2A03::audio_buffer[AUDIO_BUFFER_SIZE * 2];
@@ -394,7 +393,7 @@ inline void Apu2A03::writeBuffer()
     static size_t dummy;
     i2s_write(I2S_NUM_0, audio_buffer, sizeof(audio_buffer), &dummy, portMAX_DELAY);
 #else
-    while ((_audio_w - _audio_r) + AUDIO_BUFFER_SIZE > sizeof(_audio_buffer)) vTaskDelay(1);
+    while (cv_audio_buffer_full(AUDIO_BUFFER_SIZE)) vTaskDelay(1);
     audio_write_16((const uint16_t*)audio_buffer, AUDIO_BUFFER_SIZE, 2);
 #endif
 }

--- a/src/core/apu2A03.h
+++ b/src/core/apu2A03.h
@@ -7,7 +7,11 @@
 #include "config.h"
 #include "driver/i2s.h"
 
-#define SAMPLE_RATE       44100
+#ifndef COMPOSITE_VIDEO
+    #define SAMPLE_RATE 44100
+#else
+    #define SAMPLE_RATE 15720
+#endif
 #define AUDIO_BUFFER_SIZE 128
 
 class Bus;
@@ -199,6 +203,7 @@ private:
     bool DMC_enable = false;
 
     void generateSample();
+    void writeBuffer();
 
     void pulseChannelClock(sequencerUnit& seq, bool enable);
     void triangleChannelClock(triangleChannel& triangle, bool enable);

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -131,10 +131,12 @@ void Bus::connectFramebuffer(uint8_t* framebuffer)
 
 IRAM_ATTR void Bus::renderImage(uint16_t scanline)
 {
-#ifndef DISABLE_DMA
+#ifndef COMPOSITE_VIDEO
+    #ifndef DISABLE_DMA
     ptr_screen->pushPixelsDMA(ppu.ptr_display, 256 * SCANLINES_PER_BUFFER);
-#else
+    #else
     ptr_screen->pushPixels(ppu.ptr_display, 256 * SCANLINES_PER_BUFFER);
+    #endif
 #endif
 }
 

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -124,6 +124,11 @@ void Bus::connectScreen(TFT_eSPI* screen)
     ptr_screen = screen;
 }
 
+void Bus::connectFramebuffer(uint8_t* framebuffer)
+{
+    ppu.connectFramebuffer(framebuffer);
+}
+
 IRAM_ATTR void Bus::renderImage(uint16_t scanline)
 {
 #ifndef DISABLE_DMA

--- a/src/core/bus.h
+++ b/src/core/bus.h
@@ -31,6 +31,7 @@ public:
 
     void insertCartridge(Cartridge* cartridge);
     void connectScreen(TFT_eSPI* screen);
+    void connectFramebuffer(uint8_t* framebuffer);
     void reset();
     void clock();
     void IRQ();

--- a/src/core/ppu2C02.cpp
+++ b/src/core/ppu2C02.cpp
@@ -2,14 +2,18 @@
 #include "bus.h"
 
 #define READ_PALETTE(x) palette_table[((x) & 0x1F) ^ (((x) & 0x13) == 0x10 ? 0x10 : 0x00)]
-#ifdef ILI9341_DRIVER
+
+#ifndef COMPOSITE_VIDEO
+    #ifdef ILI9341_DRIVER
 DMA_ATTR uint16_t Ppu2C02::display_buffer_front[SCANLINE_SIZE * SCANLINES_PER_BUFFER];
 DMA_ATTR uint16_t Ppu2C02::display_buffer_back[SCANLINE_SIZE * SCANLINES_PER_BUFFER];
 uint16_t* Ppu2C02::ptr_display = Ppu2C02::display_buffer_front;
 uint16_t* Ppu2C02::ptr_back_buffer = Ppu2C02::display_buffer_back;
-#else
+    #else
 DMA_ATTR uint16_t Ppu2C02::display_buffer[SCANLINE_SIZE * SCANLINES_PER_BUFFER];
+    #endif
 #endif
+
 constexpr uint8_t Ppu2C02::palette_mirror[32];
 
 Ppu2C02::Ppu2C02()
@@ -26,13 +30,15 @@ Ppu2C02::Ppu2C02()
     memset(palette_table, 0, sizeof(palette_table));
     memset(scanline_buffer, 0, sizeof(scanline_buffer));
     memset(scanline_metadata, 0, sizeof(scanline_metadata));
-#ifdef ILI9341_DRIVER
+    memset(sprite, 0, sizeof(sprite));
+#ifndef COMPOSITE_VIDEO
+    #ifdef ILI9341_DRIVER
     memset(display_buffer_front, 0, sizeof(display_buffer_front));
     memset(display_buffer_back, 0, sizeof(display_buffer_back));
-#else
+    #else
     memset(display_buffer, 0, sizeof(display_buffer));
+    #endif
 #endif
-    memset(sprite, 0, sizeof(sprite));
 }
 
 Ppu2C02::~Ppu2C02()
@@ -511,26 +517,30 @@ inline void Ppu2C02::finishScanline()
     if (mask.render_background || mask.render_sprite) cart->ppuScanline();
 
 // Transfer internal scanline buffer to display buffer
-#ifdef ILI9341_DRIVER
+#ifndef COMPOSITE_VIDEO
+    #ifdef ILI9341_DRIVER
     uint16_t* display = ptr_back_buffer + ((uint32_t)scanline_counter * SCANLINE_SIZE);
-#else
+    #else
     uint16_t* display = ptr_display + ((uint32_t)scanline_counter * SCANLINE_SIZE);
-#endif
+    #endif
     uint8_t* buffer = ptr_buffer;
     for (int i = 0; i < SCANLINE_SIZE; i++) display[i] = nes_palette[mask.emphasize][buffer[i]];
 
     scanline_counter++;
     if (scanline_counter >= SCANLINES_PER_BUFFER)
     {
-#ifdef ILI9341_DRIVER
+    #ifdef ILI9341_DRIVER
         uint16_t* temp = ptr_display;
         ptr_display = ptr_back_buffer;
         ptr_back_buffer = temp;
-#endif
-
+    #endif
         bus->renderImage(scanline - (SCANLINES_PER_BUFFER - 1));
         scanline_counter = 0;
     }
+#else
+    uint8_t* buffer = ptr_buffer;
+    for (int i = 0; i < SCANLINE_SIZE; i++) display_buffer[scanline * 256 + i] = buffer[i] & 0x3F;
+#endif
 }
 
 void Ppu2C02::reset()
@@ -672,4 +682,10 @@ void Ppu2C02::loadState(File& state)
     state.read((uint8_t*)&x, sizeof(x));
     state.read((uint8_t*)&w, sizeof(w));
     state.read((uint8_t*)&PPUDATA_buffer, sizeof(PPUDATA_buffer));
+}
+
+void Ppu2C02::connectFramebuffer(uint8_t* framebuffer)
+{
+    display_buffer = framebuffer;
+    ptr_display = display_buffer;
 }

--- a/src/core/ppu2C02.h
+++ b/src/core/ppu2C02.h
@@ -42,6 +42,7 @@ public:
         bus = n;
     }
     void connectCartridge(Cartridge* cartridge);
+    void connectFramebuffer(uint8_t* framebuffer);
     void setMirror(Cartridge::MIRROR mirror);
     Cartridge::MIRROR getMirror();
 
@@ -71,14 +72,17 @@ private:
     uint8_t* ptr_nametable[4];
     uint8_t palette_table[32];
     uint8_t scanline_counter = 0;
-
     uint8_t scanline_buffer[BUFFER_SIZE];
     uint8_t scanline_metadata[BUFFER_SIZE];
-#ifdef ILI9341_DRIVER
+#ifdef COMPOSITE_VIDEO
+    uint8_t* display_buffer = nullptr;
+#else
+    #ifdef ILI9341_DRIVER
     static uint16_t display_buffer_front[SCANLINE_SIZE * SCANLINES_PER_BUFFER];
     static uint16_t display_buffer_back[SCANLINE_SIZE * SCANLINES_PER_BUFFER];
-#else
+    #else
     static uint16_t display_buffer[SCANLINE_SIZE * SCANLINES_PER_BUFFER];
+    #endif
 #endif
 
     // clang-format off
@@ -855,11 +859,15 @@ private:
 public:
     uint8_t* ptr_sprite = (uint8_t*)sprite;
     uint8_t* ptr_buffer = scanline_buffer;
-#ifdef ILI9341_DRIVER
+#ifdef COMPOSITE_VIDEO
+    uint8_t* ptr_display;
+#else
+    #ifdef ILI9341_DRIVER
     static uint16_t* ptr_display;
     static uint16_t* ptr_back_buffer;
-#else
+    #else
     static constexpr uint16_t* ptr_display = display_buffer;
+    #endif
 #endif
 };
 


### PR DESCRIPTION
## Composite Video Output

Adds composite video and audio output support to Anemoia-ESP32, enabling the emulator to run on a CRT television via composite input.

### Changes

**Video**
- Integrated composite video output based on [esp_8_bit](https://github.com/rossumur/esp_8_bit) by Peter Barrett ([@rossumur](https://github.com/rossumur))
- Added composite framebuffer rendering pipeline and game selection and pause menu UI
- Added `COMPOSITE_VIDEO` preprocessor flag to toggle between composite and TFT output at compile time

**Audio**
- APU sample rate adjusted to 15720Hz to match the NTSC scanline ISR drain rate
- I2S audio path preserved and unchanged for non-composite builds
- Default audio pin is GPIO18, configurable in `config.h`

**Config**
- `COMPOSITE_VIDEO` and `AUDIO_PIN` added to `config.h`

### Testing
- Video and audio verified on physical CRT hardware

### Credits

Composite video implementation is based and has been adapted from [esp_8_bit](https://github.com/rossumur/esp_8_bit) by Peter Barrett ([@rossumur](https://github.com/rossumur)).

Closes #49