### PR TITLE
perf: bus r/w LUT dispatch — achieves 60 fps without frame skip

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -121,11 +121,12 @@ jobs:
       - name: Build defines and platform flags
         run: |
           DEFINES=""
-          [ "${{ matrix.swap }}"   = "swap_bytes" ] && DEFINES="$DEFINES -DSCREEN_SWAP_BYTES" || DEFINES="$DEFINES -USCREEN_SWAP_BYTES"
-          [ "${{ matrix.debug }}"  = "debug_on"   ] && DEFINES="$DEFINES -DDEBUG"             || DEFINES="$DEFINES -UDEBUG"
-          [ "${{ matrix.device }}" = "cyd"        ] && DEFINES="$DEFINES -DCHEAP_YELLOW_DISPLAY_CONF"
-          [ "${{ matrix.device }}" = "module"     ] && DEFINES="$DEFINES -DMODULE_BASED_PCB_CONF"
-          [ "${{ matrix.device }}" = "discrete"   ] && DEFINES="$DEFINES -DDISCRETE_PCB_CONF"
+          [ "${{ matrix.swap }}"        = "swap_bytes" ]        && DEFINES="$DEFINES -DSCREEN_SWAP_BYTES" || DEFINES="$DEFINES -USCREEN_SWAP_BYTES"
+          [ "${{ matrix.debug }}"       = "debug_on"   ]        && DEFINES="$DEFINES -DDEBUG"             || DEFINES="$DEFINES -UDEBUG"
+          [ "${{ matrix.device }}"      = "cyd"        ]        && DEFINES="$DEFINES -DCHEAP_YELLOW_DISPLAY_CONF"
+          [ "${{ matrix.device }}"      = "module"     ]        && DEFINES="$DEFINES -DMODULE_BASED_PCB_CONF"
+          [ "${{ matrix.device }}"      = "discrete"   ]        && DEFINES="$DEFINES -DDISCRETE_PCB_CONF"
+          [ "${{ matrix.screen_freq }}" = "screen_freq_40MHz" ] && DEFINES="$DEFINES -DFRAMESKIP" || DEFINES="$DEFINES -UFRAMESKIP"
           PLATFORM_FLAGS="-DOPTIMIZATION_FLAGS -Ofast -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -funroll-loops -fno-tree-vectorize -frename-registers -fno-plt -flto"
 
           echo "DEFINES=$DEFINES" >> $GITHUB_ENV

--- a/Anemoia-ESP32.ino
+++ b/Anemoia-ESP32.ino
@@ -131,7 +131,8 @@ unsigned long frame_count = 0;
 #endif
 IRAM_ATTR void emulate()
 {
-    Bus nes;
+    Bus* bus = new Bus();
+    Bus& nes = *bus;
 #ifdef COMPOSITE_VIDEO
     nes.connectFramebuffer(cv_framebuffer);
 #else

--- a/Anemoia-ESP32.ino
+++ b/Anemoia-ESP32.ino
@@ -25,6 +25,8 @@ SPIClass SD_SPI(SD_SPI_PORT);
 TFT_eSPI screen = TFT_eSPI();
 UI ui(&screen);
 #endif
+
+static Bus nes;
 Cartridge* cart;
 
 RTC_NOINIT_ATTR bool demo_mode_reset;
@@ -131,8 +133,6 @@ unsigned long frame_count = 0;
 #endif
 IRAM_ATTR void emulate()
 {
-    Bus* bus = new Bus();
-    Bus& nes = *bus;
 #ifdef COMPOSITE_VIDEO
     nes.connectFramebuffer(cv_framebuffer);
 #else

--- a/config.h
+++ b/config.h
@@ -8,6 +8,10 @@
 #endif
 #define AUDIO_PIN 18
 
+// Uncomment #define FRAMESKIP if you are using less than 80MHz display SPI frequency
+// This will skip displaying every other frame (effectively displaying 30 FPS)
+// #define FRAMESKIP
+
 // #define CHEAP_YELLOW_DISPLAY_CONF // Uncomment this line if using the CYD
 // #define MODULE_BASED_PCB_CONF // Uncomment this line if using the module PCB
 // #define DISCRETE_PCB_CONF // Uncomment this line if using the discrete PCB
@@ -87,7 +91,6 @@
     #define I2S_LRC_PIN              39 // Word select / Left-Right clock (LRC / WS)
     #define I2S_DOUT_PIN             40 // Serial data output (DIN)
 
-    #define FRAMESKIP
     // #define DEBUG // Uncomment this line if you want debug prints from serial
 
 #endif

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -63,21 +63,16 @@ IRAM_ATTR void Bus::clock()
     // Using a counter/for loop with += 341 & -= 3 is too big of a performance hit.
     // 1 scanline == ~113.67 CPU clocks, so for every 3 scanlines, two scanlines will have an extra
     // CPU clock
-
-    static bool frame_latch = false;
     for (int ppu_scanline = 0; ppu_scanline < 240; ppu_scanline += 3)
     {
         cpu.clock(113);
-        if (!frame_latch) ppu.renderScanline(ppu_scanline);
-        else ppu.fakeSpriteHit(ppu_scanline);
+        ppu.renderScanline(ppu_scanline);
 
         cpu.clock(114);
-        if (!frame_latch) ppu.renderScanline(ppu_scanline + 1);
-        else ppu.fakeSpriteHit(ppu_scanline + 1);
+        ppu.renderScanline(ppu_scanline + 1);
 
         cpu.clock(114);
-        if (!frame_latch) ppu.renderScanline(ppu_scanline + 2);
-        else ppu.fakeSpriteHit(ppu_scanline + 2);
+        ppu.renderScanline(ppu_scanline + 2);
     }
 
     // Setup for the next frame
@@ -91,10 +86,6 @@ IRAM_ATTR void Bus::clock()
 
     ppu.clearVBlank();
     cpu.clock(114);
-
-#ifdef FRAMESKIP
-    frame_latch = !frame_latch;
-#endif
 }
 
 IRAM_ATTR void Bus::setPPUMirrorMode(Cartridge::MIRROR mirror)

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -52,6 +52,7 @@ IRAM_ATTR void Bus::clock()
     // Using a counter/for loop with += 341 & -= 3 is too big of a performance hit.
     // 1 scanline == ~113.67 CPU clocks, so for every 3 scanlines, two scanlines will have an extra
     // CPU clock
+#ifndef FRAMESKIP
     for (int ppu_scanline = 0; ppu_scanline < 240; ppu_scanline += 3)
     {
         cpu.clock(113);
@@ -75,6 +76,27 @@ IRAM_ATTR void Bus::clock()
 
     ppu.clearVBlank();
     cpu.clock(114);
+#else
+    static bool frame_latch = false;
+    for (int ppu_scanline = 0; ppu_scanline < 240; ppu_scanline += 3)
+    {
+        cpu.clock(113);
+        if (frame_latch) ppu.fakeSpriteHit(ppu_scanline);
+        else ppu.renderScanline(ppu_scanline);
+        cpu.clock(114);
+        if (frame_latch) ppu.fakeSpriteHit(ppu_scanline + 1);
+        else ppu.renderScanline(ppu_scanline + 1);
+        cpu.clock(114);
+        if (frame_latch) ppu.fakeSpriteHit(ppu_scanline + 2);
+        else ppu.renderScanline(ppu_scanline + 2);
+    }
+    cpu.clock(113);
+    ppu.setVBlank();
+    cpu.clock(2501);
+    ppu.clearVBlank();
+    cpu.clock(114);
+    frame_latch = !frame_latch;
+#endif
 }
 
 IRAM_ATTR void Bus::setPPUMirrorMode(MIRROR mirror)

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -30,10 +30,14 @@ IRAM_ATTR uint8_t Bus::cpuRead(uint16_t addr)
 
 void Bus::reset()
 {
-    buildPageTables();
     for (auto& i : RAM) i = 0x00;
+
+    buildPageTables();
     cart->reset();
     cart->mapPages(this);
+    ppu.buildPPUPageTables();
+    cart->mapPPUPages(&ppu);
+
     cpu.reset();
     ppu.reset();
 }
@@ -73,12 +77,12 @@ IRAM_ATTR void Bus::clock()
     cpu.clock(114);
 }
 
-IRAM_ATTR void Bus::setPPUMirrorMode(Cartridge::MIRROR mirror)
+IRAM_ATTR void Bus::setPPUMirrorMode(MIRROR mirror)
 {
     ppu.setMirror(mirror);
 }
 
-Cartridge::MIRROR Bus::getPPUMirrorMode()
+MIRROR Bus::getPPUMirrorMode()
 {
     return ppu.getMirror();
 }

--- a/src/core/bus.cpp
+++ b/src/core/bus.cpp
@@ -14,41 +14,26 @@ Bus::~Bus()
 
 IRAM_ATTR void Bus::cpuWrite(uint16_t addr, uint8_t data)
 {
-    if (cart->cpuWrite(addr, data)) {}
-    else if ((addr & 0xE000) == 0x0000) { RAM[addr & 0x07FF] = data; }
-    else if ((addr & 0xE000) == 0x2000) { ppu.cpuWrite(addr & 0x0007, data); }
-    else if (addr == 0x4014) { cpu.OAM_DMA(data); }
-    else if ((addr & 0xF000) == 0x4000 && (addr <= 0x4013 || addr == 0x4015 || addr == 0x4017))
+    if (uint8_t* p = write_pages[addr >> 8])
     {
-        cpu.apuWrite(addr, data);
+        p[addr & 0xFF] = data;
+        return;
     }
-    else if (addr == 0x4016)
-    {
-        controller_strobe = data & 1;
-        if (controller_strobe) { controller_state = controller; }
-    }
+    write_handlers[addr >> 8](this, addr, data);
 }
 
 IRAM_ATTR uint8_t Bus::cpuRead(uint16_t addr)
 {
-    uint8_t data = 0x00;
-
-    if (cart->cpuRead(addr, data)) {}
-    else if ((addr & 0xE000) == 0x0000) { data = RAM[addr & 0x07FF]; }
-    else if ((addr & 0xE000) == 0x2000) { data = ppu.cpuRead(addr & 0x0007); }
-    else if (addr == 0x4016)
-    {
-        uint8_t value = controller_state & 1;
-        if (!controller_strobe) controller_state >>= 1;
-        data = value | 0x40;
-    }
-    return data;
+    if (uint8_t* p = read_pages[addr >> 8]) return p[addr & 0xFF];
+    return read_handlers[addr >> 8](this, addr);
 }
 
 void Bus::reset()
 {
+    buildPageTables();
     for (auto& i : RAM) i = 0x00;
     cart->reset();
+    cart->mapPages(this);
     cpu.reset();
     ppu.reset();
 }
@@ -140,6 +125,65 @@ IRAM_ATTR void Bus::IRQ()
 IRAM_ATTR void Bus::NMI()
 {
     cpu.NMI();
+}
+
+static void defaultWriteHandler(Bus* b, uint16_t a, uint8_t d)
+{
+    return;
+}
+
+static uint8_t defaultReadHandler(Bus* b, uint16_t a)
+{
+    return 0x00;
+}
+
+// Builds the memory map for bus read and writes
+void Bus::buildPageTables()
+{
+    for (int p = 0; p < NUM_PAGES; p++)
+    {
+        read_pages[p] = nullptr;
+        write_pages[p] = nullptr;
+        read_handlers[p] = defaultReadHandler;
+        write_handlers[p] = defaultWriteHandler;
+    }
+
+    // $0000 - $1FFF: 2KB RAM mirrored x4
+    for (int p = 0x00; p <= 0x1F; p++)
+    {
+        uint8_t* base = &RAM[(p % 8) * PAGE_SIZE];
+        read_pages[p] = base;
+        write_pages[p] = base;
+    }
+
+    // $2000 - $3FFF: PPU registers, mirrored every 8 bytes
+    for (int p = 0x20; p <= 0x3F; p++)
+    {
+        read_handlers[p] = [](Bus* b, uint16_t a) -> uint8_t { return b->ppu.cpuRead(a & 0x0007); };
+        write_handlers[p] = [](Bus* b, uint16_t a, uint8_t d) { b->ppu.cpuWrite(a & 0x0007, d); };
+    }
+
+    // $4000 - $401F: APU/IO
+    read_handlers[0x40] = [](Bus* b, uint16_t a) -> uint8_t
+    {
+        if (a == 0x4016)
+        {
+            uint8_t value = b->controller_state & 1;
+            if (!b->controller_strobe) b->controller_state >>= 1;
+            return value | 0x40;
+        }
+        return 0x00;
+    };
+    write_handlers[0x40] = [](Bus* b, uint16_t a, uint8_t d)
+    {
+        if (a == 0x4014) b->cpu.OAM_DMA(d);
+        else if (a <= 0x4013 || a == 0x4015 || a == 0x4017) b->cpu.apuWrite(a, d);
+        else if (a == 0x4016)
+        {
+            b->controller_strobe = d & 1;
+            if (b->controller_strobe) b->controller_state = b->controller;
+        }
+    };
 }
 
 void Bus::saveState()

--- a/src/core/bus.h
+++ b/src/core/bus.h
@@ -25,8 +25,8 @@ public:
 
     void cpuWrite(uint16_t addr, uint8_t data);
     uint8_t cpuRead(uint16_t addr);
-    void setPPUMirrorMode(Cartridge::MIRROR mirror);
-    Cartridge::MIRROR getPPUMirrorMode();
+    void setPPUMirrorMode(MIRROR mirror);
+    MIRROR getPPUMirrorMode();
 
     void insertCartridge(Cartridge* cartridge);
     void connectScreen(TFT_eSPI* screen);

--- a/src/core/bus.h
+++ b/src/core/bus.h
@@ -17,7 +17,6 @@ public:
     Bus();
     ~Bus();
 
-public:
     Cpu6502 cpu;
     Ppu2C02 ppu;
     Cartridge* cart;
@@ -41,6 +40,19 @@ public:
 
     void saveState();
     void loadState();
+
+    static constexpr int PAGE_SIZE = 256;
+    static constexpr int NUM_PAGES = 0x10000 / PAGE_SIZE;
+
+    uint8_t* read_pages[NUM_PAGES] = {};
+    uint8_t* write_pages[NUM_PAGES] = {};
+
+    using ReadHandler = uint8_t (*)(Bus*, uint16_t);
+    using WriteHandler = void (*)(Bus*, uint16_t, uint8_t);
+    ReadHandler read_handlers[NUM_PAGES] = {};
+    WriteHandler write_handlers[NUM_PAGES] = {};
+
+    void buildPageTables();
 
 private:
     void cpuClock();

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -74,11 +74,7 @@ bool Cartridge::cpuRead(uint16_t addr, uint8_t& data)
 {
     switch (mapper_ID)
     {
-    case 0: return mapper000_cpuRead(&mapper, addr, data);
-    case 1: return mapper001_cpuRead(&mapper, addr, data);
-    case 2: return mapper002_cpuRead(&mapper, addr, data);
     case 3: return mapper003_cpuRead(&mapper, addr, data);
-    case 4: return mapper004_cpuRead(&mapper, addr, data);
     case 69: return mapper069_cpuRead(&mapper, addr, data);
     default: return false;
     }
@@ -88,11 +84,7 @@ bool Cartridge::cpuWrite(uint16_t addr, uint8_t data)
 {
     switch (mapper_ID)
     {
-    case 0: return mapper000_cpuWrite(&mapper, addr, data);
-    case 1: return mapper001_cpuWrite(&mapper, addr, data);
-    case 2: return mapper002_cpuWrite(&mapper, addr, data);
     case 3: return mapper003_cpuWrite(&mapper, addr, data);
-    case 4: return mapper004_cpuWrite(&mapper, addr, data);
     case 69: return mapper069_cpuWrite(&mapper, addr, data);
     default: return false;
     }
@@ -169,6 +161,18 @@ void Cartridge::reset()
     case 4: return mapper004_reset(&mapper);
     case 69: return mapper069_reset(&mapper);
     default: return;
+    }
+}
+
+void Cartridge::mapPages(Bus* bus)
+{
+    switch (mapper_ID)
+    {
+    case 0: mapper000_mapPages(&mapper, bus); break;
+    case 1: mapper001_mapPages(&mapper, bus); break;
+    case 2: mapper002_mapPages(&mapper, bus); break;
+    case 4: mapper004_mapPages(&mapper, bus); break;
+    default: break;
     }
 }
 
@@ -251,9 +255,7 @@ void Cartridge::createMapper(uint8_t number_PRG_banks, uint8_t number_CHR_banks,
     case 0: mapper = createMapper000(number_PRG_banks, number_CHR_banks, backend, this); break;
     case 1: mapper = createMapper001(number_PRG_banks, number_CHR_banks, backend, this); break;
     case 2: mapper = createMapper002(number_PRG_banks, number_CHR_banks, backend, this); break;
-    case 3: mapper = createMapper003(number_PRG_banks, number_CHR_banks, backend, this); break;
     case 4: mapper = createMapper004(number_PRG_banks, number_CHR_banks, backend, this); break;
-    case 69: mapper = createMapper069(number_PRG_banks, number_CHR_banks, backend, this); break;
     default: is_valid = false; break;
     }
 }

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -71,68 +71,6 @@ Cartridge::~Cartridge()
 {
 }
 
-bool Cartridge::cpuRead(uint16_t addr, uint8_t& data)
-{
-    switch (mapper_ID)
-    {
-    case 3: return mapper003_cpuRead(&mapper, addr, data);
-    case 69: return mapper069_cpuRead(&mapper, addr, data);
-    default: return false;
-    }
-}
-
-bool Cartridge::cpuWrite(uint16_t addr, uint8_t data)
-{
-    switch (mapper_ID)
-    {
-    case 3: return mapper003_cpuWrite(&mapper, addr, data);
-    case 69: return mapper069_cpuWrite(&mapper, addr, data);
-    default: return false;
-    }
-}
-
-bool Cartridge::ppuRead(uint16_t addr, uint8_t& data)
-{
-    switch (mapper_ID)
-    {
-    case 0: return mapper000_ppuRead(&mapper, addr, data);
-    case 1: return mapper001_ppuRead(&mapper, addr, data);
-    case 2: return mapper002_ppuRead(&mapper, addr, data);
-    case 3: return mapper003_ppuRead(&mapper, addr, data);
-    case 4: return mapper004_ppuRead(&mapper, addr, data);
-    case 69: return mapper069_ppuRead(&mapper, addr, data);
-    default: return false;
-    }
-}
-
-bool Cartridge::ppuWrite(uint16_t addr, uint8_t data)
-{
-    switch (mapper_ID)
-    {
-    case 0: return mapper000_ppuWrite(&mapper, addr, data);
-    case 1: return mapper001_ppuWrite(&mapper, addr, data);
-    case 2: return mapper002_ppuWrite(&mapper, addr, data);
-    case 3: return mapper003_ppuWrite(&mapper, addr, data);
-    case 4: return mapper004_ppuWrite(&mapper, addr, data);
-    case 69: return mapper069_ppuWrite(&mapper, addr, data);
-    default: return false;
-    }
-}
-
-uint8_t* Cartridge::ppuReadPtr(uint16_t addr)
-{
-    switch (mapper_ID)
-    {
-    case 0: return mapper000_ppuReadPtr(&mapper, addr);
-    case 1: return mapper001_ppuReadPtr(&mapper, addr);
-    case 2: return mapper002_ppuReadPtr(&mapper, addr);
-    case 3: return mapper003_ppuReadPtr(&mapper, addr);
-    case 4: return mapper004_ppuReadPtr(&mapper, addr);
-    case 69: return mapper069_ppuReadPtr(&mapper, addr);
-    default: return nullptr;
-    }
-}
-
 void Cartridge::ppuScanline()
 {
     switch (mapper_ID)

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -110,7 +110,9 @@ void Cartridge::mapPages(Bus* bus)
     case 0: mapper000_mapPages(&mapper, bus); break;
     case 1: mapper001_mapPages(&mapper, bus); break;
     case 2: mapper002_mapPages(&mapper, bus); break;
+    case 3: mapper003_mapPages(&mapper, bus); break;
     case 4: mapper004_mapPages(&mapper, bus); break;
+    case 69: mapper069_mapPages(&mapper, bus); break;
     default: break;
     }
 }
@@ -122,7 +124,9 @@ void Cartridge::mapPPUPages(Ppu2C02* ppu)
     case 0: mapper000_mapPPUPages(&mapper, ppu); break;
     case 1: mapper001_mapPPUPages(&mapper, ppu); break;
     case 2: mapper002_mapPPUPages(&mapper, ppu); break;
+    case 3: mapper003_mapPPUPages(&mapper, ppu); break;
     case 4: mapper004_mapPPUPages(&mapper, ppu); break;
+    case 69: mapper069_mapPPUPages(&mapper, ppu); break;
     default: break;
     }
 }
@@ -204,7 +208,9 @@ void Cartridge::createMapper(uint8_t number_PRG_banks, uint8_t number_CHR_banks,
     case 0: mapper = createMapper000(number_PRG_banks, number_CHR_banks, backend, this); break;
     case 1: mapper = createMapper001(number_PRG_banks, number_CHR_banks, backend, this); break;
     case 2: mapper = createMapper002(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 3: mapper = createMapper003(number_PRG_banks, number_CHR_banks, backend, this); break;
     case 4: mapper = createMapper004(number_PRG_banks, number_CHR_banks, backend, this); break;
+    case 69: mapper = createMapper069(number_PRG_banks, number_CHR_banks, backend, this); break;
     default: is_valid = false; break;
     }
 }

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -1,5 +1,6 @@
 #include "cartridge.h"
 #include "bus.h"
+#include "ppu2C02.h"
 
 Cartridge::Cartridge(const char* filename, ROMBackend backend)
 {
@@ -24,7 +25,7 @@ Cartridge::Cartridge(const char* filename, ROMBackend backend)
     if (header.mapper1 & 0x04) rom.seek(rom.position() + 512);
 
     mapper_ID = (header.mapper2 & 0xF0) | header.mapper1 >> 4;
-    hardware_mirror = (header.mapper1 & 0x01) ? VERTICAL : HORIZONTAL;
+    hardware_mirror = (header.mapper1 & 0x01) ? MIRROR::VERTICAL : MIRROR::HORIZONTAL;
 
     uint8_t number_PRG_banks = 0;
     uint8_t number_CHR_banks = 0;
@@ -176,6 +177,18 @@ void Cartridge::mapPages(Bus* bus)
     }
 }
 
+void Cartridge::mapPPUPages(Ppu2C02* ppu)
+{
+    switch (mapper_ID)
+    {
+    case 0: mapper000_mapPPUPages(&mapper, ppu); break;
+    // case 1: mapper001_mapPPUPages(&mapper, ppu); break;
+    // case 2: mapper002_mapPPUPages(&mapper, ppu); break;
+    // case 4: mapper004_mapPPUPages(&mapper, ppu); break;
+    default: break;
+    }
+}
+
 IRAM_ATTR void Cartridge::loadPRGBank(uint8_t* bank, uint16_t size, uint32_t offset)
 {
     rom.seek(prg_base + offset);
@@ -193,7 +206,7 @@ IRAM_ATTR void Cartridge::setMirrorMode(MIRROR mirror)
     bus->setPPUMirrorMode(mirror);
 }
 
-Cartridge::MIRROR Cartridge::getMirrorMode()
+MIRROR Cartridge::getMirrorMode()
 {
     return bus->getPPUMirrorMode();
 }
@@ -205,7 +218,6 @@ void Cartridge::IRQ()
 
 void Cartridge::dumpState(File& state)
 {
-    // mapper.vtable->dumpState(&mapper, state);
     switch (mapper_ID)
     {
     case 0: return mapper000_dumpState(&mapper, state);
@@ -220,7 +232,6 @@ void Cartridge::dumpState(File& state)
 
 void Cartridge::loadState(File& state)
 {
-    // mapper.vtable->loadState(&mapper, state);
     switch (mapper_ID)
     {
     case 0: return mapper000_loadState(&mapper, state);

--- a/src/core/cartridge.cpp
+++ b/src/core/cartridge.cpp
@@ -182,9 +182,9 @@ void Cartridge::mapPPUPages(Ppu2C02* ppu)
     switch (mapper_ID)
     {
     case 0: mapper000_mapPPUPages(&mapper, ppu); break;
-    // case 1: mapper001_mapPPUPages(&mapper, ppu); break;
-    // case 2: mapper002_mapPPUPages(&mapper, ppu); break;
-    // case 4: mapper004_mapPPUPages(&mapper, ppu); break;
+    case 1: mapper001_mapPPUPages(&mapper, ppu); break;
+    case 2: mapper002_mapPPUPages(&mapper, ppu); break;
+    case 4: mapper004_mapPPUPages(&mapper, ppu); break;
     default: break;
     }
 }

--- a/src/core/cartridge.h
+++ b/src/core/cartridge.h
@@ -40,6 +40,8 @@ public:
     void cpuCycle(int cycles);
     void reset();
 
+    void mapPages(Bus* bus);
+
     void loadPRGBank(uint8_t* bank, uint16_t size, uint32_t offset);
     void loadCHRBank(uint8_t* bank, uint16_t size, uint32_t offset);
     void setMirrorMode(MIRROR mirror);
@@ -61,6 +63,7 @@ public:
     uint8_t mirror = HORIZONTAL;
     uint32_t CRC32 = ~0U;
     MappedROM mROM;
+    Mapper mapper;
 
 private:
     Bus* bus = nullptr;
@@ -69,7 +72,6 @@ private:
     uint32_t chr_base;
 
     File rom;
-    Mapper mapper;
     uint8_t mapper_ID = 0;
     void createMapper(uint8_t number_PRG_banks, uint8_t number_CHR_banks, ROMBackend backend);
     uint32_t crc32(const void* buf, size_t size, uint32_t seed = ~0U);

--- a/src/core/cartridge.h
+++ b/src/core/cartridge.h
@@ -13,6 +13,8 @@
 #include "mappers/mapper003.h"
 #include "mappers/mapper004.h"
 #include "mappers/mapper069.h"
+#include "mirror_mode.h"
+#include "ppu2C02.h"
 #include "rom_backends.h"
 
 class Bus;
@@ -21,15 +23,6 @@ class Cartridge
 public:
     Cartridge(const char* filename, ROMBackend backend = ROMBackend::LRU);
     ~Cartridge();
-
-    enum MIRROR : uint8_t
-    {
-        HORIZONTAL,
-        VERTICAL,
-        ONESCREEN_LOW,
-        ONESCREEN_HIGH,
-        HARDWARE
-    };
 
     bool cpuRead(uint16_t addr, uint8_t& data);
     bool cpuWrite(uint16_t addr, uint8_t data);
@@ -41,11 +34,12 @@ public:
     void reset();
 
     void mapPages(Bus* bus);
+    void mapPPUPages(Ppu2C02* ppu);
 
     void loadPRGBank(uint8_t* bank, uint16_t size, uint32_t offset);
     void loadCHRBank(uint8_t* bank, uint16_t size, uint32_t offset);
     void setMirrorMode(MIRROR mirror);
-    Cartridge::MIRROR getMirrorMode();
+    MIRROR getMirrorMode();
     void connectBus(Bus* n)
     {
         bus = n;
@@ -59,8 +53,8 @@ public:
     void seek(uint32_t offset);
     void read(uint8_t* buf, size_t size);
 
-    uint8_t hardware_mirror;
-    uint8_t mirror = HORIZONTAL;
+    MIRROR hardware_mirror;
+    MIRROR mirror = MIRROR::HORIZONTAL;
     uint32_t CRC32 = ~0U;
     MappedROM mROM;
     Mapper mapper;

--- a/src/core/cartridge.h
+++ b/src/core/cartridge.h
@@ -24,11 +24,6 @@ public:
     Cartridge(const char* filename, ROMBackend backend = ROMBackend::LRU);
     ~Cartridge();
 
-    bool cpuRead(uint16_t addr, uint8_t& data);
-    bool cpuWrite(uint16_t addr, uint8_t data);
-    bool ppuRead(uint16_t addr, uint8_t& data);
-    uint8_t* ppuReadPtr(uint16_t addr);
-    bool ppuWrite(uint16_t addr, uint8_t data);
     void ppuScanline();
     void cpuCycle(int cycles);
     void reset();

--- a/src/core/cpu6502.cpp
+++ b/src/core/cpu6502.cpp
@@ -48,7 +48,6 @@ IRAM_ATTR void Cpu6502::clock(int i)
         if (cycles > 0)
         {
             cycles--;
-            cart->cpuCycle(1);
             continue;
         }
 
@@ -335,14 +334,12 @@ IRAM_ATTR void Cpu6502::clock(int i)
         if (remaining_cycles >= cycles)
         {
             remaining_cycles -= (cycles - 1);
-            cart->cpuCycle(cycles);
             cycles = 0;
             continue;
         }
         else
         {
             cycles -= remaining_cycles;
-            cart->cpuCycle(remaining_cycles);
             return;
         }
     }

--- a/src/core/cpu6502.cpp
+++ b/src/core/cpu6502.cpp
@@ -48,6 +48,7 @@ IRAM_ATTR void Cpu6502::clock(int i)
         if (cycles > 0)
         {
             cycles--;
+            cart->cpuCycle(1);
             continue;
         }
 
@@ -334,12 +335,14 @@ IRAM_ATTR void Cpu6502::clock(int i)
         if (remaining_cycles >= cycles)
         {
             remaining_cycles -= (cycles - 1);
+            cart->cpuCycle(cycles);
             cycles = 0;
             continue;
         }
         else
         {
             cycles -= remaining_cycles;
+            cart->cpuCycle(remaining_cycles);
             return;
         }
     }

--- a/src/core/mapper.h
+++ b/src/core/mapper.h
@@ -14,6 +14,8 @@
 #include "rom_types.h"
 
 class Cartridge;
+class Bus;
+class Ppu2C02;
 class Mapper
 {
 public:

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -3,14 +3,6 @@
 #include "../cartridge.h"
 #include "../ppu2C02.h"
 
-uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr)
-{
-    if (addr > 0x1FFF) return nullptr;
-
-    Mapper000_state* state = (Mapper000_state*)mapper->state;
-    return &state->CHR_bank[addr];
-}
-
 void mapper000_reset(Mapper* mapper)
 {
     Mapper000_state* state = (Mapper000_state*)mapper->state;

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -1,22 +1,6 @@
 #include "mapper000.h"
+#include "../bus.h"
 #include "../cartridge.h"
-
-bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr < 0x8000) return false;
-
-    Mapper000_state* state = (Mapper000_state*)mapper->state;
-    uint16_t offset = addr & 0x3FFF;
-    uint8_t bank_id = (addr >> 14) & 1;
-
-    data = state->PRG_banks[bank_id][offset];
-    return true;
-}
-
-bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    return false;
-}
 
 bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
 {
@@ -74,6 +58,17 @@ void mapper000_reset(Mapper* mapper)
         state->CHR_bank =
             (state->number_CHR_banks == 0) ? state->CHR_ROM : (uint8_t*)state->mROM->chr_base;
     }
+}
+
+void mapper000_mapPages(Mapper* mapper, Bus* bus)
+{
+    Mapper000_state* state = (Mapper000_state*)mapper->state;
+
+    // $8000-$BFFF: bank 0, $C000-$FFFF: bank 1 (mirrors bank 0 if only 1 bank present)
+    for (int p = 0x80; p <= 0xBF; p++)
+        bus->read_pages[p] = state->PRG_banks[0] + ((p - 0x80) * 256);
+    for (int p = 0xC0; p <= 0xFF; p++)
+        bus->read_pages[p] = state->PRG_banks[1] + ((p - 0xC0) * 256);
 }
 
 void mapper000_dumpState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper000.cpp
+++ b/src/core/mappers/mapper000.cpp
@@ -1,30 +1,7 @@
 #include "mapper000.h"
 #include "../bus.h"
 #include "../cartridge.h"
-
-bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper000_state* state = (Mapper000_state*)mapper->state;
-    data = state->CHR_bank[addr];
-    return true;
-}
-
-bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper000_state* state = (Mapper000_state*)mapper->state;
-    if (state->number_CHR_banks == 0)
-    {
-        // Treat as RAM
-        state->CHR_bank[addr] = data;
-        return true;
-    }
-
-    return false;
-}
+#include "../ppu2C02.h"
 
 uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr)
 {
@@ -69,6 +46,18 @@ void mapper000_mapPages(Mapper* mapper, Bus* bus)
         bus->read_pages[p] = state->PRG_banks[0] + ((p - 0x80) * 256);
     for (int p = 0xC0; p <= 0xFF; p++)
         bus->read_pages[p] = state->PRG_banks[1] + ((p - 0xC0) * 256);
+}
+
+void mapper000_mapPPUPages(Mapper* mapper, Ppu2C02* ppu)
+{
+    Mapper000_state* state = (Mapper000_state*)mapper->state;
+
+    // $0000-1FFF: CHR-ROM/RAM
+    for (int p = 0x00; p <= 0x1F; p++)
+    {
+        ppu->ppu_read_pages[p] = state->CHR_bank + (p * 256);
+        if (state->number_CHR_banks == 0) ppu->ppu_write_pages[p] = state->CHR_bank + (p * 256);
+    }
 }
 
 void mapper000_dumpState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper000.h
+++ b/src/core/mappers/mapper000.h
@@ -3,6 +3,7 @@
 
 #include "../mapper.h"
 
+class Bus;
 struct Mapper000_state
 {
     Cartridge* cart = nullptr;
@@ -18,8 +19,7 @@ struct Mapper000_state
 
 Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
-bool mapper000_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper000_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
+void mapper000_mapPages(Mapper* mapper, Bus* bus);
 bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper000.h
+++ b/src/core/mappers/mapper000.h
@@ -20,9 +20,6 @@ Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
 
 void mapper000_mapPages(Mapper* mapper, Bus* bus);
 void mapper000_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
-bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr);
 void mapper000_reset(Mapper* mapper);
 void mapper000_dumpState(Mapper* mapper, File& state);
 void mapper000_loadState(Mapper* mapper, File& state);

--- a/src/core/mappers/mapper000.h
+++ b/src/core/mappers/mapper000.h
@@ -3,8 +3,6 @@
 
 #include "../mapper.h"
 
-class Bus;
-class Ppu2C02;
 struct Mapper000_state
 {
     Cartridge* cart = nullptr;

--- a/src/core/mappers/mapper000.h
+++ b/src/core/mappers/mapper000.h
@@ -4,6 +4,7 @@
 #include "../mapper.h"
 
 class Bus;
+class Ppu2C02;
 struct Mapper000_state
 {
     Cartridge* cart = nullptr;
@@ -20,6 +21,7 @@ struct Mapper000_state
 Mapper createMapper000(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 void mapper000_mapPages(Mapper* mapper, Bus* bus);
+void mapper000_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
 bool mapper000_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper000_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper000_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -132,6 +132,7 @@ static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
                                    state->CHR_bank_0 * 4U * 1024);
                     else state->ptr_CHR_bank_4K[0] = getCHRBank4K(state, state->CHR_bank_0);
                 }
+                mapper001_remapCHRPages(state, &bus->ppu);
                 break;
 
             // CHR bank 1 Register
@@ -145,6 +146,7 @@ static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
                                    state->CHR_bank_1 * 4U * 1024);
                     else state->ptr_CHR_bank_4K[1] = getCHRBank4K(state, state->CHR_bank_1);
                 }
+                mapper001_remapWindows(state, bus);
                 break;
 
             // PRG bank Register
@@ -168,16 +170,15 @@ static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
                     break;
                 default: break;
                 }
+                mapper001_remapWindows(state, bus);
                 break;
+
             default: break;
             }
 
             // Reset Load Register and counter
             state->load = 0x00;
             state->load_writes = 0;
-
-            mapper001_remapWindows(state, bus);
-            mapper001_remapCHRPages(state, &bus->ppu);
         }
     }
     else

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -1,6 +1,7 @@
 #include "mapper001.h"
 #include "../bus.h"
 #include "../cartridge.h"
+#include "../ppu2C02.h"
 
 struct Mapper001_state
 {
@@ -60,6 +61,33 @@ static void mapper001_remapWindows(Mapper001_state* state, Bus* bus)
 
     for (int p = 0x80; p <= 0xBF; p++) bus->read_pages[p] = windows[0] + ((p - 0x80) * 256);
     for (int p = 0xC0; p <= 0xFF; p++) bus->read_pages[p] = windows[1] + ((p - 0xC0) * 256);
+}
+
+static void mapper001_remapCHRPages(Mapper001_state* state, Ppu2C02* ppu)
+{
+    if (state->CHR_ROM_bank_mode == 0)
+    {
+        for (int p = 0x00; p <= 0x1F; p++)
+        {
+            ppu->ppu_read_pages[p] = state->ptr_CHR_bank_8K + (p * 256);
+            if (state->number_CHR_banks == 0)
+                ppu->ppu_write_pages[p] = state->ptr_CHR_bank_8K + (p * 256);
+        }
+        return;
+    }
+
+    for (int p = 0x00; p <= 0x0F; p++)
+    {
+        ppu->ppu_read_pages[p] = state->ptr_CHR_bank_4K[0] + (p * 256);
+        if (state->number_CHR_banks == 0)
+            ppu->ppu_write_pages[p] = state->ptr_CHR_bank_4K[0] + (p * 256);
+    }
+    for (int p = 0x10; p <= 0x1F; p++)
+    {
+        ppu->ppu_read_pages[p] = state->ptr_CHR_bank_4K[1] + (p * 256);
+        if (state->number_CHR_banks == 0)
+            ppu->ppu_write_pages[p] = state->ptr_CHR_bank_4K[1] + (p * 256);
+    }
 }
 
 static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
@@ -149,6 +177,7 @@ static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
             state->load_writes = 0;
 
             mapper001_remapWindows(state, bus);
+            mapper001_remapCHRPages(state, &bus->ppu);
         }
     }
     else
@@ -273,6 +302,12 @@ void mapper001_mapPages(Mapper* mapper, Bus* bus)
 
     // Map bank reads
     mapper001_remapWindows(state, bus);
+}
+
+void mapper001_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
+{
+    Mapper001_state* state = (Mapper001_state*)mapper->state;
+    mapper001_remapCHRPages(state, ppu);
 }
 
 void mapper001_dumpState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -84,9 +84,9 @@ static void mapper001_remapCHRPages(Mapper001_state* state, Ppu2C02* ppu)
     }
     for (int p = 0x10; p <= 0x1F; p++)
     {
-        ppu->ppu_read_pages[p] = state->ptr_CHR_bank_4K[1] + (p * 256);
+        ppu->ppu_read_pages[p] = state->ptr_CHR_bank_4K[1] + ((p - 0x10) * 256);
         if (state->number_CHR_banks == 0)
-            ppu->ppu_write_pages[p] = state->ptr_CHR_bank_4K[1] + (p * 256);
+            ppu->ppu_write_pages[p] = state->ptr_CHR_bank_4K[1] + ((p - 0x10) * 256);
     }
 }
 

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -188,40 +188,6 @@ static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
     }
 }
 
-bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (state->CHR_ROM_bank_mode == 0) { data = state->ptr_CHR_bank_8K[addr & 0x1FFF]; }
-    else { data = state->ptr_CHR_bank_4K[(addr >> 12) & 1][addr & 0x0FFF]; }
-    return true;
-}
-
-bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (state->number_CHR_banks == 0)
-    {
-        // Treat as RAM
-        state->CHR_RAM[addr & 0x1FFF] = data;
-        return true;
-    }
-
-    return false;
-}
-
-uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr)
-{
-    if (addr > 0x1FFF) return nullptr;
-
-    Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (state->CHR_ROM_bank_mode == 0) return &state->ptr_CHR_bank_8K[addr & 0x1FFF];
-    else return &state->ptr_CHR_bank_4K[(addr >> 12) & 1][addr & 0x0FFF];
-}
-
 void mapper001_reset(Mapper* mapper)
 {
     Mapper001_state* state = (Mapper001_state*)mapper->state;
@@ -304,7 +270,7 @@ void mapper001_mapPages(Mapper* mapper, Bus* bus)
     mapper001_remapWindows(state, bus);
 }
 
-void mapper001_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
+void mapper001_mapPPUPages(Mapper* mapper, Ppu2C02* ppu)
 {
     Mapper001_state* state = (Mapper001_state*)mapper->state;
     mapper001_remapCHRPages(state, ppu);

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -1,4 +1,5 @@
 #include "mapper001.h"
+#include "../bus.h"
 #include "../cartridge.h"
 
 struct Mapper001_state
@@ -11,9 +12,9 @@ struct Mapper001_state
 
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
-    uint8_t* ptr_16K_PRG_banks[4];
-    uint8_t* ptr_8K_CHR_bank;
-    uint8_t* ptr_4K_CHR_banks[2];
+    uint8_t* ptr_PRG_bank_16K[4];
+    uint8_t* ptr_CHR_bank_8K;
+    uint8_t* ptr_CHR_bank_4K[2];
 
     Bank PRG_banks_16K[MAPPER001_NUM_PRG_BANKS_16K];
     Bank CHR_banks_8K[MAPPER001_NUM_CHR_BANKS_8K];
@@ -45,39 +46,27 @@ static inline uint8_t* getCHRBank4K(Mapper001_state* state, uint8_t index);
 static inline void loadCHRRAM(Mapper001_state* state, uint8_t* bank, uint16_t size,
                               uint32_t offset);
 
-bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+static void mapper001_remapWindows(Mapper001_state* state, Bus* bus)
 {
-    if (addr < 0x6000) return false;
-
-    Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (addr < 0x8000)
-    {
-        data = state->RAM[addr & 0x1FFF];
-        return true;
-    }
-
+    uint8_t* windows[2];
     if (state->PRG_ROM_bank_mode < 2)
     {
-        uint8_t bank = ((addr >> 14) & 0x01) + 2;
-        data = state->ptr_16K_PRG_banks[bank][addr & 0x3FFF];
-        return true;
+        windows[0] = state->ptr_PRG_bank_16K[2];
+        windows[1] = state->ptr_PRG_bank_16K[3];
+    }
+    else
+    {
+        windows[0] = state->ptr_PRG_bank_16K[0];
+        windows[1] = state->ptr_PRG_bank_16K[1];
     }
 
-    data = state->ptr_16K_PRG_banks[(addr >> 14) & 1][addr & 0x3FFF];
-    return true;
+    for (int p = 0x80; p <= 0xBF; p++) bus->read_pages[p] = windows[0] + ((p - 0x80) * 256);
+    for (int p = 0xC0; p <= 0xFF; p++) bus->read_pages[p] = windows[1] + ((p - 0xC0) * 256);
 }
 
-bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
 {
-    if (addr < 0x6000) return false;
-
-    Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (addr < 0x8000)
-    {
-        state->RAM[addr & 0x1FFF] = data;
-        return true;
-    }
-
+    Mapper001_state* state = (Mapper001_state*)bus->cart->mapper.state;
     // If bit 7 is set clear load shift register
     if (!(data & 0x80))
     {
@@ -106,16 +95,16 @@ bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 if (state->CHR_ROM_bank_mode == 0)
                 {
                     if (state->number_CHR_banks == 0)
-                        loadCHRRAM(state, state->ptr_8K_CHR_bank, 8U * 1024U,
+                        loadCHRRAM(state, state->ptr_CHR_bank_8K, 8U * 1024U,
                                    (state->CHR_bank_0 & 0x1E) * 8U * 1024U);
-                    else state->ptr_8K_CHR_bank = getCHRBank8K(state, state->CHR_bank_0 & 0x1E);
+                    else state->ptr_CHR_bank_8K = getCHRBank8K(state, state->CHR_bank_0 & 0x1E);
                 }
                 else
                 {
                     if (state->number_CHR_banks == 0)
-                        loadCHRRAM(state, state->ptr_4K_CHR_banks[0], 4U * 1024,
+                        loadCHRRAM(state, state->ptr_CHR_bank_4K[0], 4U * 1024,
                                    state->CHR_bank_0 * 4U * 1024);
-                    else state->ptr_4K_CHR_banks[0] = getCHRBank4K(state, state->CHR_bank_0);
+                    else state->ptr_CHR_bank_4K[0] = getCHRBank4K(state, state->CHR_bank_0);
                 }
                 break;
 
@@ -126,9 +115,9 @@ bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 if (state->CHR_ROM_bank_mode == 1)
                 {
                     if (state->number_CHR_banks == 0)
-                        loadCHRRAM(state, state->ptr_4K_CHR_banks[1], 4U * 1024,
+                        loadCHRRAM(state, state->ptr_CHR_bank_4K[1], 4U * 1024,
                                    state->CHR_bank_1 * 4U * 1024);
-                    else state->ptr_4K_CHR_banks[1] = getCHRBank4K(state, state->CHR_bank_1);
+                    else state->ptr_CHR_bank_4K[1] = getCHRBank4K(state, state->CHR_bank_1);
                 }
                 break;
 
@@ -140,16 +129,16 @@ bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
                 {
                 case 0:
                 case 1:
-                    state->ptr_16K_PRG_banks[2] = getPRGBank(state, state->PRG_bank & 0x0E);
-                    state->ptr_16K_PRG_banks[3] = getPRGBank(state, (state->PRG_bank & 0x0E) + 1);
+                    state->ptr_PRG_bank_16K[2] = getPRGBank(state, state->PRG_bank & 0x0E);
+                    state->ptr_PRG_bank_16K[3] = getPRGBank(state, (state->PRG_bank & 0x0E) + 1);
                     break;
                 case 2:
-                    state->ptr_16K_PRG_banks[0] = getPRGBank(state, 0);
-                    state->ptr_16K_PRG_banks[1] = getPRGBank(state, state->PRG_bank & 0x0F);
+                    state->ptr_PRG_bank_16K[0] = getPRGBank(state, 0);
+                    state->ptr_PRG_bank_16K[1] = getPRGBank(state, state->PRG_bank & 0x0F);
                     break;
                 case 3:
-                    state->ptr_16K_PRG_banks[0] = getPRGBank(state, state->PRG_bank & 0x0F);
-                    state->ptr_16K_PRG_banks[1] = getPRGBank(state, state->number_PRG_banks - 1);
+                    state->ptr_PRG_bank_16K[0] = getPRGBank(state, state->PRG_bank & 0x0F);
+                    state->ptr_PRG_bank_16K[1] = getPRGBank(state, state->number_PRG_banks - 1);
                     break;
                 default: break;
                 }
@@ -160,6 +149,8 @@ bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
             // Reset Load Register and counter
             state->load = 0x00;
             state->load_writes = 0;
+
+            mapper001_remapWindows(state, bus);
         }
     }
     else
@@ -168,7 +159,6 @@ bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
         state->load_writes = 0;
         state->control |= 0x0C;
     }
-    return true;
 }
 
 bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
@@ -176,8 +166,8 @@ bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     if (addr > 0x1FFF) return false;
 
     Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (state->CHR_ROM_bank_mode == 0) { data = state->ptr_8K_CHR_bank[addr & 0x1FFF]; }
-    else { data = state->ptr_4K_CHR_banks[(addr >> 12) & 1][addr & 0x0FFF]; }
+    if (state->CHR_ROM_bank_mode == 0) { data = state->ptr_CHR_bank_8K[addr & 0x1FFF]; }
+    else { data = state->ptr_CHR_bank_4K[(addr >> 12) & 1][addr & 0x0FFF]; }
     return true;
 }
 
@@ -201,8 +191,8 @@ uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr)
     if (addr > 0x1FFF) return nullptr;
 
     Mapper001_state* state = (Mapper001_state*)mapper->state;
-    if (state->CHR_ROM_bank_mode == 0) return &state->ptr_8K_CHR_bank[addr & 0x1FFF];
-    else return &state->ptr_4K_CHR_banks[(addr >> 12) & 1][addr & 0x0FFF];
+    if (state->CHR_ROM_bank_mode == 0) return &state->ptr_CHR_bank_8K[addr & 0x1FFF];
+    else return &state->ptr_CHR_bank_4K[(addr >> 12) & 1][addr & 0x0FFF];
 }
 
 void mapper001_reset(Mapper* mapper)
@@ -217,44 +207,44 @@ void mapper001_reset(Mapper* mapper)
         if (state->number_CHR_banks == 0)
         {
             // Point 4K banks into the same memory
-            state->ptr_8K_CHR_bank = state->CHR_RAM;
-            state->ptr_4K_CHR_banks[0] = state->CHR_RAM;
-            state->ptr_4K_CHR_banks[1] = state->CHR_RAM + 0x1000;
+            state->ptr_CHR_bank_8K = state->CHR_RAM;
+            state->ptr_CHR_bank_4K[0] = state->CHR_RAM;
+            state->ptr_CHR_bank_4K[1] = state->CHR_RAM + 0x1000;
         }
         else
         {
-            state->ptr_8K_CHR_bank = getBank(&state->CHR_8K_cache, 0, RomType::CHR);
-            state->ptr_4K_CHR_banks[0] = getBank(&state->CHR_4K_cache, 0, RomType::CHR);
-            state->ptr_4K_CHR_banks[1] = getBank(&state->CHR_4K_cache, 1, RomType::CHR);
+            state->ptr_CHR_bank_8K = getBank(&state->CHR_8K_cache, 0, RomType::CHR);
+            state->ptr_CHR_bank_4K[0] = getBank(&state->CHR_4K_cache, 0, RomType::CHR);
+            state->ptr_CHR_bank_4K[1] = getBank(&state->CHR_4K_cache, 1, RomType::CHR);
         }
 
-        state->ptr_16K_PRG_banks[0] = getBank(&state->PRG_16K_cache, 0, RomType::PRG);
-        state->ptr_16K_PRG_banks[1] =
+        state->ptr_PRG_bank_16K[0] = getBank(&state->PRG_16K_cache, 0, RomType::PRG);
+        state->ptr_PRG_bank_16K[1] =
             getBank(&state->PRG_16K_cache, state->number_PRG_banks - 1, RomType::PRG);
-        state->ptr_16K_PRG_banks[2] = getBank(&state->PRG_16K_cache, 0, RomType::PRG);
-        state->ptr_16K_PRG_banks[3] = getBank(&state->PRG_16K_cache, 1, RomType::PRG);
+        state->ptr_PRG_bank_16K[2] = getBank(&state->PRG_16K_cache, 0, RomType::PRG);
+        state->ptr_PRG_bank_16K[3] = getBank(&state->PRG_16K_cache, 1, RomType::PRG);
         break;
 
     case ROMBackend::FLASH:
         if (state->number_CHR_banks == 0)
         {
             // Point 4K banks into the same memory
-            state->ptr_8K_CHR_bank = state->CHR_RAM;
-            state->ptr_4K_CHR_banks[0] = state->CHR_RAM;
-            state->ptr_4K_CHR_banks[1] = state->CHR_RAM + 0x1000;
+            state->ptr_CHR_bank_8K = state->CHR_RAM;
+            state->ptr_CHR_bank_4K[0] = state->CHR_RAM;
+            state->ptr_CHR_bank_4K[1] = state->CHR_RAM + 0x1000;
         }
         else
         {
-            state->ptr_8K_CHR_bank = (uint8_t*)state->mROM->chr_base;
-            state->ptr_4K_CHR_banks[0] = (uint8_t*)state->mROM->chr_base;
-            state->ptr_4K_CHR_banks[1] = (uint8_t*)state->mROM->chr_base;
+            state->ptr_CHR_bank_8K = (uint8_t*)state->mROM->chr_base;
+            state->ptr_CHR_bank_4K[0] = (uint8_t*)state->mROM->chr_base;
+            state->ptr_CHR_bank_4K[1] = (uint8_t*)state->mROM->chr_base;
         }
 
-        state->ptr_16K_PRG_banks[0] = (uint8_t*)state->mROM->prg_base;
-        state->ptr_16K_PRG_banks[1] =
+        state->ptr_PRG_bank_16K[0] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_16K[1] =
             (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - (16U * 1024U)));
-        state->ptr_16K_PRG_banks[2] = (uint8_t*)state->mROM->prg_base;
-        state->ptr_16K_PRG_banks[3] = (uint8_t*)(state->mROM->prg_base + (16U * 1024U));
+        state->ptr_PRG_bank_16K[2] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_16K[3] = (uint8_t*)(state->mROM->prg_base + (16U * 1024U));
         break;
     }
 
@@ -267,6 +257,24 @@ void mapper001_reset(Mapper* mapper)
     state->CHR_bank_1 = 0x00;
     state->PRG_bank = 0x00;
     state->cart->setMirrorMode(Cartridge::MIRROR::HORIZONTAL);
+}
+
+void mapper001_mapPages(Mapper* mapper, Bus* bus)
+{
+    Mapper001_state* state = (Mapper001_state*)mapper->state;
+
+    // $6000-$7FFF: 8KB PRG-RAM
+    for (int p = 0x60; p <= 0x7F; p++)
+    {
+        bus->read_pages[p] = state->RAM + ((p - 0x60) * 256);
+        bus->write_pages[p] = state->RAM + ((p - 0x60) * 256);
+    }
+
+    // $8000-$FFFF: Shift register
+    for (int p = 0x80; p <= 0xFF; p++) bus->write_handlers[p] = mapper001_shiftWrite;
+
+    // Map bank reads
+    mapper001_remapWindows(state, bus);
 }
 
 void mapper001_dumpState(Mapper* mapper, File& state)
@@ -291,14 +299,14 @@ void mapper001_dumpState(Mapper* mapper, File& state)
     {
     case ROMBackend::LRU:
         for (int i = 0; i < 4; i++)
-            PRG_16K[i] = getBankIndex(&s->PRG_16K_cache, s->ptr_16K_PRG_banks[i]);
+            PRG_16K[i] = getBankIndex(&s->PRG_16K_cache, s->ptr_PRG_bank_16K[i]);
         state.write(PRG_16K, sizeof(PRG_16K));
         if (s->number_CHR_banks == 0) { state.write(s->CHR_RAM, 8U * 1024U); }
         else
         {
-            CHR_8K = getBankIndex(&s->CHR_8K_cache, s->ptr_8K_CHR_bank);
+            CHR_8K = getBankIndex(&s->CHR_8K_cache, s->ptr_CHR_bank_8K);
             for (int i = 0; i < 2; i++)
-                CHR_4K[i] = getBankIndex(&s->CHR_4K_cache, s->ptr_4K_CHR_banks[i]);
+                CHR_4K[i] = getBankIndex(&s->CHR_4K_cache, s->ptr_CHR_bank_4K[i]);
 
             state.write((uint8_t*)&CHR_8K, sizeof(CHR_8K));
             state.write(CHR_4K, sizeof(CHR_4K));
@@ -308,16 +316,16 @@ void mapper001_dumpState(Mapper* mapper, File& state)
     case ROMBackend::FLASH:
         for (int i = 0; i < 4; i++)
         {
-            PRG_16K[i] = (s->ptr_16K_PRG_banks[i] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
+            PRG_16K[i] = (s->ptr_PRG_bank_16K[i] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
         }
         state.write(PRG_16K, sizeof(PRG_16K));
 
         if (s->number_CHR_banks == 0) { state.write(s->CHR_RAM, 8U * 1024U); }
         else
         {
-            CHR_8K = (s->ptr_8K_CHR_bank - (uint8_t*)s->mROM->chr_base) / (8U * 1024U);
+            CHR_8K = (s->ptr_CHR_bank_8K - (uint8_t*)s->mROM->chr_base) / (8U * 1024U);
             for (int i = 0; i < 2; i++)
-                CHR_4K[i] = (s->ptr_4K_CHR_banks[i] - (uint8_t*)s->mROM->chr_base) / (4U * 1024U);
+                CHR_4K[i] = (s->ptr_CHR_bank_4K[i] - (uint8_t*)s->mROM->chr_base) / (4U * 1024U);
 
             state.write((uint8_t*)&CHR_8K, sizeof(CHR_8K));
             state.write(CHR_4K, sizeof(CHR_4K));
@@ -351,7 +359,7 @@ void mapper001_loadState(Mapper* mapper, File& state)
         state.read(PRG_16K, sizeof(PRG_16K));
         invalidateCache(&s->PRG_16K_cache);
         for (int i = 0; i < 4; i++)
-            s->ptr_16K_PRG_banks[i] = getBank(&s->PRG_16K_cache, PRG_16K[i], RomType::PRG);
+            s->ptr_PRG_bank_16K[i] = getBank(&s->PRG_16K_cache, PRG_16K[i], RomType::PRG);
         if (s->number_CHR_banks == 0) { state.read(s->CHR_RAM, 8U * 1024U); }
         else
         {
@@ -360,9 +368,9 @@ void mapper001_loadState(Mapper* mapper, File& state)
 
             invalidateCache(&s->CHR_8K_cache);
             invalidateCache(&s->CHR_4K_cache);
-            s->ptr_8K_CHR_bank = getBank(&s->CHR_8K_cache, CHR_8K, RomType::CHR);
+            s->ptr_CHR_bank_8K = getBank(&s->CHR_8K_cache, CHR_8K, RomType::CHR);
             for (int i = 0; i < 2; i++)
-                s->ptr_4K_CHR_banks[i] = getBank(&s->CHR_4K_cache, CHR_4K[i], RomType::CHR);
+                s->ptr_CHR_bank_4K[i] = getBank(&s->CHR_4K_cache, CHR_4K[i], RomType::CHR);
         }
         return;
 
@@ -370,7 +378,7 @@ void mapper001_loadState(Mapper* mapper, File& state)
         state.read(PRG_16K, sizeof(PRG_16K));
         for (int i = 0; i < 4; i++)
         {
-            s->ptr_16K_PRG_banks[i] =
+            s->ptr_PRG_bank_16K[i] =
                 (uint8_t*)(s->mROM->prg_base + (uint32_t)PRG_16K[i] * (16U * 1024U));
         }
 
@@ -380,9 +388,9 @@ void mapper001_loadState(Mapper* mapper, File& state)
             state.read((uint8_t*)&CHR_8K, sizeof(CHR_8K));
             state.read(CHR_4K, sizeof(CHR_4K));
 
-            s->ptr_8K_CHR_bank = (uint8_t*)(s->mROM->chr_base + (uint32_t)CHR_8K * (8U * 1024U));
+            s->ptr_CHR_bank_8K = (uint8_t*)(s->mROM->chr_base + (uint32_t)CHR_8K * (8U * 1024U));
             for (int i = 0; i < 2; i++)
-                s->ptr_4K_CHR_banks[i] =
+                s->ptr_CHR_bank_4K[i] =
                     (uint8_t*)(s->mROM->chr_base + (uint32_t)CHR_4K[i] * (4U * 1024U));
         }
         return;

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -146,7 +146,7 @@ static void mapper001_shiftWrite(Bus* bus, uint16_t addr, uint8_t data)
                                    state->CHR_bank_1 * 4U * 1024);
                     else state->ptr_CHR_bank_4K[1] = getCHRBank4K(state, state->CHR_bank_1);
                 }
-                mapper001_remapWindows(state, bus);
+                mapper001_remapCHRPages(state, &bus->ppu);
                 break;
 
             // PRG bank Register

--- a/src/core/mappers/mapper001.cpp
+++ b/src/core/mappers/mapper001.cpp
@@ -34,12 +34,10 @@ struct Mapper001_state
     uint8_t CHR_bank_1 = 0x00; // CHR Bank 1 Register
     uint8_t PRG_bank = 0x00;   // PRG Bank Register
 
-    static constexpr Cartridge::MIRROR mirror[4] = { Cartridge::MIRROR::ONESCREEN_LOW,
-                                                     Cartridge::MIRROR::ONESCREEN_HIGH,
-                                                     Cartridge::MIRROR::VERTICAL,
-                                                     Cartridge::MIRROR::HORIZONTAL };
+    static constexpr MIRROR mirror[4] = { MIRROR::ONESCREEN_LOW, MIRROR::ONESCREEN_HIGH,
+                                          MIRROR::VERTICAL, MIRROR::HORIZONTAL };
 };
-constexpr Cartridge::MIRROR Mapper001_state::mirror[4];
+constexpr MIRROR Mapper001_state::mirror[4];
 static inline uint8_t* getPRGBank(Mapper001_state* state, uint8_t index);
 static inline uint8_t* getCHRBank8K(Mapper001_state* state, uint8_t index);
 static inline uint8_t* getCHRBank4K(Mapper001_state* state, uint8_t index);
@@ -256,7 +254,7 @@ void mapper001_reset(Mapper* mapper)
     state->CHR_bank_0 = 0x00;
     state->CHR_bank_1 = 0x00;
     state->PRG_bank = 0x00;
-    state->cart->setMirrorMode(Cartridge::MIRROR::HORIZONTAL);
+    state->cart->setMirrorMode(MIRROR::HORIZONTAL);
 }
 
 void mapper001_mapPages(Mapper* mapper, Bus* bus)
@@ -280,7 +278,7 @@ void mapper001_mapPages(Mapper* mapper, Bus* bus)
 void mapper001_dumpState(Mapper* mapper, File& state)
 {
     Mapper001_state* s = (Mapper001_state*)mapper->state;
-    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+    MIRROR mirror = s->cart->getMirrorMode();
     state.write((uint8_t*)&s->load, sizeof(s->load));
     state.write((uint8_t*)&s->control, sizeof(s->control));
     state.write((uint8_t*)&s->load_writes, sizeof(s->load_writes));
@@ -337,7 +335,7 @@ void mapper001_dumpState(Mapper* mapper, File& state)
 void mapper001_loadState(Mapper* mapper, File& state)
 {
     Mapper001_state* s = (Mapper001_state*)mapper->state;
-    Cartridge::MIRROR mirror;
+    MIRROR mirror;
     state.read((uint8_t*)&s->load, sizeof(s->load));
     state.read((uint8_t*)&s->control, sizeof(s->control));
     state.read((uint8_t*)&s->load_writes, sizeof(s->load_writes));

--- a/src/core/mappers/mapper001.h
+++ b/src/core/mappers/mapper001.h
@@ -7,10 +7,10 @@
 #define MAPPER001_NUM_CHR_BANKS_8K  1
 #define MAPPER001_NUM_CHR_BANKS_4K  5
 
+class Bus;
 Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
-bool mapper001_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper001_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
+void mapper001_mapPages(Mapper* mapper, Bus* bus);
 bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper001.h
+++ b/src/core/mappers/mapper001.h
@@ -11,9 +11,6 @@ Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
 
 void mapper001_mapPages(Mapper* mapper, Bus* bus);
 void mapper001_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
-bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr);
 void mapper001_reset(Mapper* mapper);
 void mapper001_dumpState(Mapper* mapper, File& state);
 void mapper001_loadState(Mapper* mapper, File& state);

--- a/src/core/mappers/mapper001.h
+++ b/src/core/mappers/mapper001.h
@@ -5,7 +5,7 @@
 
 #define MAPPER001_NUM_PRG_BANKS_16K 8
 #define MAPPER001_NUM_CHR_BANKS_8K  1
-#define MAPPER001_NUM_CHR_BANKS_4K  5
+#define MAPPER001_NUM_CHR_BANKS_4K  3
 
 Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 

--- a/src/core/mappers/mapper001.h
+++ b/src/core/mappers/mapper001.h
@@ -7,10 +7,10 @@
 #define MAPPER001_NUM_CHR_BANKS_8K  1
 #define MAPPER001_NUM_CHR_BANKS_4K  5
 
-class Bus;
 Mapper createMapper001(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 void mapper001_mapPages(Mapper* mapper, Bus* bus);
+void mapper001_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
 bool mapper001_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper001_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper001_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -1,27 +1,22 @@
 #include "mapper002.h"
+#include "../bus.h"
 #include "../cartridge.h"
 
-bool mapper002_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+static void mapper002_remapWindows(Mapper002_state* state, Bus* bus)
 {
-    if (addr < 0x8000) return false;
-
-    Mapper002_state* state = (Mapper002_state*)mapper->state;
-    uint16_t offset = addr & 0x3FFF;
-    uint8_t bank_id = (addr >> 14) & 1;
-    data = state->ptr_16K_PRG_banks[bank_id][offset];
-    return true;
+    for (int p = 0x80; p <= 0xBF; p++)
+        bus->read_pages[p] = state->ptr_PRG_bank_16K[0] + ((p - 0x80) * 256);
 }
 
-bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+static void mapper002_bankWrite(Bus* bus, uint16_t addr, uint8_t data)
 {
-    if (addr < 0x8000) return false;
+    Mapper002_state* state = (Mapper002_state*)bus->cart->mapper.state;
 
-    Mapper002_state* state = (Mapper002_state*)mapper->state;
     uint8_t bank = data & 0x0F;
     if (state->backend == ROMBackend::LRU)
-        state->ptr_16K_PRG_banks[0] = getBank(&state->prg_cache, bank, RomType::PRG);
-    else state->ptr_16K_PRG_banks[0] = (uint8_t*)(state->mROM->prg_base + (bank * 16U * 1024U));
-    return true;
+        state->ptr_PRG_bank_16K[0] = getBank(&state->PRG_cache_16K, bank, RomType::PRG);
+    else state->ptr_PRG_bank_16K[0] = (uint8_t*)(state->mROM->prg_base + (bank * 16U * 1024U));
+    mapper002_remapWindows(state, bus);
 }
 
 bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
@@ -62,22 +57,41 @@ void mapper002_reset(Mapper* mapper)
     switch (state->backend)
     {
     case ROMBackend::LRU:
-        state->ptr_16K_PRG_banks[0] = getBank(&state->prg_cache, 0, RomType::PRG);
-        state->ptr_16K_PRG_banks[1] = state->PRG_bank;
+        state->ptr_PRG_bank_16K[0] = getBank(&state->PRG_cache_16K, 0, RomType::PRG);
+        state->ptr_PRG_bank_16K[1] = state->PRG_bank;
 
-        state->cart->loadPRGBank(state->ptr_16K_PRG_banks[1], 16U * 1024U,
+        state->cart->loadPRGBank(state->ptr_PRG_bank_16K[1], 16U * 1024U,
                                  0x4000 * (state->number_PRG_banks - 1));
         state->cart->loadCHRBank(state->CHR_bank, 8U * 1024U, 0);
         return;
 
     case ROMBackend::FLASH:
-        state->ptr_16K_PRG_banks[0] = (uint8_t*)state->mROM->prg_base;
-        state->ptr_16K_PRG_banks[1] =
+        state->ptr_PRG_bank_16K[0] = (uint8_t*)state->mROM->prg_base;
+        state->ptr_PRG_bank_16K[1] =
             (uint8_t*)(state->mROM->prg_base + (state->mROM->prg_size - (16U * 1024U)));
 
         if (state->number_CHR_banks != 0) state->CHR_bank = (uint8_t*)state->mROM->chr_base;
         return;
     }
+}
+
+void mapper002_mapPages(Mapper* mapper, Bus* bus)
+{
+    Mapper002_state* state = (Mapper002_state*)mapper->state;
+
+    // $8000-$FFFF: Bank switch
+    for (int p = 0x80; p <= 0xFF; p++)
+    {
+        bus->write_pages[p] = nullptr;
+        bus->write_handlers[p] = mapper002_bankWrite;
+    }
+
+    // $C000-$FFFF: fixed to last bank, never remapped by writes
+    for (int p = 0xC0; p <= 0xFF; p++)
+        bus->read_pages[p] = state->ptr_PRG_bank_16K[1] + ((p - 0xC0) * 256);
+
+    // Map bank reads ($8000-$BFFF, switchable)
+    mapper002_remapWindows(state, bus);
 }
 
 void mapper002_dumpState(Mapper* mapper, File& state)
@@ -87,13 +101,13 @@ void mapper002_dumpState(Mapper* mapper, File& state)
     switch (s->backend)
     {
     case ROMBackend::LRU:
-        PRG_16K = getBankIndex(&s->prg_cache, s->ptr_16K_PRG_banks[0]);
+        PRG_16K = getBankIndex(&s->PRG_cache_16K, s->ptr_PRG_bank_16K[0]);
         state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
         if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, 8U * 1024U); }
         return;
 
     case ROMBackend::FLASH:
-        PRG_16K = (s->ptr_16K_PRG_banks[0] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
+        PRG_16K = (s->ptr_PRG_bank_16K[0] - (uint8_t*)s->mROM->prg_base) / (16U * 1024U);
         state.write((uint8_t*)&PRG_16K, sizeof(PRG_16K));
         if (s->number_CHR_banks == 0) { state.write(s->CHR_bank, 8U * 1024U); }
         return;
@@ -108,14 +122,14 @@ void mapper002_loadState(Mapper* mapper, File& state)
     {
     case ROMBackend::LRU:
         state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
-        invalidateCache(&s->prg_cache);
-        s->ptr_16K_PRG_banks[0] = getBank(&s->prg_cache, PRG_16K, RomType::PRG);
+        invalidateCache(&s->PRG_cache_16K);
+        s->ptr_PRG_bank_16K[0] = getBank(&s->PRG_cache_16K, PRG_16K, RomType::PRG);
         if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, 8U * 1024U); }
         return;
 
     case ROMBackend::FLASH:
         state.read((uint8_t*)&PRG_16K, sizeof(PRG_16K));
-        s->ptr_16K_PRG_banks[0] = (uint8_t*)(s->mROM->prg_base + (PRG_16K * (16U * 1024U)));
+        s->ptr_PRG_bank_16K[0] = (uint8_t*)(s->mROM->prg_base + (PRG_16K * (16U * 1024U)));
         if (s->number_CHR_banks == 0) { state.read(s->CHR_bank, 8U * 1024U); }
         return;
     }
@@ -130,8 +144,8 @@ Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
     case ROMBackend::LRU:
         state->PRG_bank = (uint8_t*)malloc(16U * 1024U);
         state->CHR_bank = (uint8_t*)malloc(8U * 1024U);
-        bankInit(&state->prg_cache, state->prg_banks, MAPPER002_NUM_PRG_BANKS_16K, 16U * 1024U,
-                 cart);
+        bankInit(&state->PRG_cache_16K, state->PRG_banks_16K, MAPPER002_NUM_PRG_BANKS_16K,
+                 16U * 1024U, cart);
         break;
 
     case ROMBackend::FLASH:

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -19,38 +19,6 @@ static void mapper002_bankWrite(Bus* bus, uint16_t addr, uint8_t data)
     mapper002_remapWindows(state, bus);
 }
 
-bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper002_state* state = (Mapper002_state*)mapper->state;
-    data = state->CHR_bank[addr];
-    return true;
-}
-
-bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper002_state* state = (Mapper002_state*)mapper->state;
-    if (state->number_CHR_banks == 0)
-    {
-        // Treat as RAM
-        state->CHR_bank[addr] = data;
-        return true;
-    }
-
-    return false;
-}
-
-uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr)
-{
-    if (addr > 0x1FFF) return nullptr;
-
-    Mapper002_state* state = (Mapper002_state*)mapper->state;
-    return &state->CHR_bank[addr];
-}
-
 void mapper002_reset(Mapper* mapper)
 {
     Mapper002_state* state = (Mapper002_state*)mapper->state;

--- a/src/core/mappers/mapper002.cpp
+++ b/src/core/mappers/mapper002.cpp
@@ -94,6 +94,16 @@ void mapper002_mapPages(Mapper* mapper, Bus* bus)
     mapper002_remapWindows(state, bus);
 }
 
+void mapper002_mapPPUPages(Mapper* mapper, Ppu2C02* ppu)
+{
+    Mapper002_state* state = (Mapper002_state*)mapper->state;
+    for (int p = 0x00; p <= 0x1F; p++)
+    {
+        ppu->ppu_read_pages[p] = state->CHR_bank + (p * 256);
+        if (state->number_CHR_banks == 0) ppu->ppu_write_pages[p] = state->CHR_bank + (p * 256);
+    }
+}
+
 void mapper002_dumpState(Mapper* mapper, File& state)
 {
     Mapper002_state* s = (Mapper002_state*)mapper->state;

--- a/src/core/mappers/mapper002.h
+++ b/src/core/mappers/mapper002.h
@@ -11,17 +11,17 @@ struct Mapper002_state
     ROMBackend backend;
     uint8_t number_PRG_banks;
     uint8_t number_CHR_banks;
-    uint8_t* ptr_16K_PRG_banks[2];
-    Bank prg_banks[MAPPER002_NUM_PRG_BANKS_16K];
-    BankCache prg_cache;
+    uint8_t* ptr_PRG_bank_16K[2];
+    Bank PRG_banks_16K[MAPPER002_NUM_PRG_BANKS_16K];
+    BankCache PRG_cache_16K;
     uint8_t* PRG_bank = nullptr;
     uint8_t* CHR_bank = nullptr;
 };
 
+class Bus;
 Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
-bool mapper002_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper002_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
+void mapper002_mapPages(Mapper* mapper, Bus* bus);
 bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper002.h
+++ b/src/core/mappers/mapper002.h
@@ -22,9 +22,6 @@ Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
 
 void mapper002_mapPages(Mapper* mapper, Bus* bus);
 void mapper002_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
-bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr);
 void mapper002_reset(Mapper* mapper);
 void mapper002_dumpState(Mapper* mapper, File& state);
 void mapper002_loadState(Mapper* mapper, File& state);

--- a/src/core/mappers/mapper002.h
+++ b/src/core/mappers/mapper002.h
@@ -18,10 +18,10 @@ struct Mapper002_state
     uint8_t* CHR_bank = nullptr;
 };
 
-class Bus;
 Mapper createMapper002(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 void mapper002_mapPages(Mapper* mapper, Bus* bus);
+void mapper002_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
 bool mapper002_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper002_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper002_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper003.cpp
+++ b/src/core/mappers/mapper003.cpp
@@ -1,47 +1,21 @@
 #include "mapper003.h"
+#include "../bus.h"
 #include "../cartridge.h"
+#include "../ppu2C02.h"
 
-bool mapper003_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+static void mapper003_remapCHRPages(Mapper003_state* state, Ppu2C02* ppu)
 {
-    if (addr < 0x8000) return false;
-
-    Mapper003_state* state = (Mapper003_state*)mapper->state;
-    data = state->PRG_bank[addr & 0x7FFF];
-    return true;
+    for (int p = 0; p <= 0x1F; p++) ppu->ppu_read_pages[p] = state->ptr_CHR_bank_8K + (p * 256);
 }
 
-bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+static void mapper003_bankWrite(Bus* bus, uint16_t addr, uint8_t data)
 {
-    if (addr < 0x8000) return false;
-
-    Mapper003_state* state = (Mapper003_state*)mapper->state;
+    Mapper003_state* state = (Mapper003_state*)bus->cart->mapper.state;
     uint8_t bank = data & 0x03;
     if (state->backend == ROMBackend::LRU)
         state->ptr_CHR_bank_8K = getBank(&state->CHR_cache_8K, bank, RomType::CHR);
     else state->ptr_CHR_bank_8K = (uint8_t*)(state->mROM->chr_base + bank * 8U * 1024U);
-    return true;
-}
-
-bool mapper003_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper003_state* state = (Mapper003_state*)mapper->state;
-    data = state->ptr_CHR_bank_8K[addr];
-    return true;
-}
-
-bool mapper003_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    return false;
-}
-
-uint8_t* mapper003_ppuReadPtr(Mapper* mapper, uint16_t addr)
-{
-    if (addr > 0x1FFF) return nullptr;
-
-    Mapper003_state* state = (Mapper003_state*)mapper->state;
-    return &state->ptr_CHR_bank_8K[addr];
+    mapper003_remapCHRPages(state, &bus->ppu);
 }
 
 void mapper003_reset(Mapper* mapper)
@@ -59,6 +33,23 @@ void mapper003_reset(Mapper* mapper)
         state->PRG_bank = (uint8_t*)state->mROM->prg_base;
         return;
     }
+}
+
+void mapper003_mapPages(Mapper* mapper, Bus* bus)
+{
+    Mapper003_state* state = (Mapper003_state*)mapper->state;
+
+    // $8000-$FFFF: Bank write to switch CHR banks
+    for (int p = 0x80; p <= 0xFF; p++) bus->write_handlers[p] = mapper003_bankWrite;
+
+    // $8000-$FFFF: 32KB unbanked PRG-ROM
+    for (int p = 0x80; p <= 0xFF; p++) bus->read_pages[p] = state->PRG_bank + ((p - 0x80) * 256);
+}
+
+void mapper003_mapPPUPages(Mapper* mapper, Ppu2C02* ppu)
+{
+    Mapper003_state* state = (Mapper003_state*)mapper->state;
+    mapper003_remapCHRPages(state, ppu);
 }
 
 void mapper003_dumpState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper003.h
+++ b/src/core/mappers/mapper003.h
@@ -3,7 +3,7 @@
 
 #include "../mapper.h"
 
-#define MAPPER003_NUM_CHR_BANKS_8K 16
+#define MAPPER003_NUM_CHR_BANKS_8K 14
 struct Mapper003_state
 {
     Cartridge* cart = nullptr;

--- a/src/core/mappers/mapper003.h
+++ b/src/core/mappers/mapper003.h
@@ -20,11 +20,8 @@ struct Mapper003_state
 
 Mapper createMapper003(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
-bool mapper003_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper003_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-bool mapper003_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper003_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-uint8_t* mapper003_ppuReadPtr(Mapper* mapper, uint16_t addr);
+void mapper003_mapPages(Mapper* mapper, Bus* bus);
+void mapper003_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
 void mapper003_reset(Mapper* mapper);
 void mapper003_dumpState(Mapper* mapper, File& state);
 void mapper003_loadState(Mapper* mapper, File& state);

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -1,4 +1,5 @@
 #include "mapper004.h"
+#include "../bus.h"
 #include "../cartridge.h"
 
 struct Mapper004_state
@@ -36,108 +37,98 @@ constexpr Cartridge::MIRROR Mapper004_state::mirror[2];
 static inline uint8_t* getPRGBank(Mapper004_state* state, uint8_t index);
 static inline uint8_t* getCHRBank(Mapper004_state* state, uint8_t index);
 
-bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+static void mapper004_remapWindows(Mapper004_state* state, Bus* bus)
 {
-    if (addr < 0x6000) return false;
-
-    Mapper004_state* state = (Mapper004_state*)mapper->state;
-    if (addr < 0x8000)
+    uint8_t* windows[4] = { state->ptr_PRG_bank_8K[0], state->ptr_PRG_bank_8K[1],
+                            state->ptr_PRG_bank_8K[2], state->ptr_PRG_bank_8K[3] };
+    for (int i = 0; i < 4; i++)
     {
-        data = state->RAM[addr & 0x1FFF];
-        return true;
+        int base = 0x80 + (i * 0x20);
+        for (int p = 0; p < 0x20; p++) bus->read_pages[base + p] = windows[i] + (p * 256);
     }
-
-    uint8_t bank = (addr >> 13) & 0x03;
-    data = state->ptr_PRG_bank_8K[bank][addr & 0x1FFF];
-    return true;
 }
 
-bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+static void mapper004_bankWrite(Bus* bus, uint16_t addr, uint8_t data)
 {
-    if (addr < 0x6000) return false;
-
-    Mapper004_state* state = (Mapper004_state*)mapper->state;
-    if (addr < 0x8000)
+    Mapper004_state* state = (Mapper004_state*)bus->cart->mapper.state;
+    if (!(addr & 0x01))
     {
-        state->RAM[addr & 0x1FFF] = data;
-        return true;
-    }
-
-    // Bank select (even address) | Bank data (odd address)
-    uint8_t bank_register[10];
-    switch (addr & 0xE001)
-    {
-    case 0x8000:
         state->bank_select = data & 0x07;
         state->PRG_ROM_bank_mode = (data >> 6) & 0x01;
         state->CHR_ROM_bank_mode = (data >> 7) & 0x01;
-        break;
-
-    case 0x8001:
-        state->bank_register[state->bank_select] = data;
-
-        bank_register[0] = (state->bank_register[0] & 0xFE) & state->CHR_mask;
-        bank_register[1] = (state->bank_register[1] & 0xFE) & state->CHR_mask;
-        bank_register[2] = state->bank_register[2] & state->CHR_mask;
-        bank_register[3] = state->bank_register[3] & state->CHR_mask;
-        bank_register[4] = state->bank_register[4] & state->CHR_mask;
-        bank_register[5] = state->bank_register[5] & state->CHR_mask;
-        bank_register[6] = state->bank_register[6] & state->PRG_mask;
-        bank_register[7] = state->bank_register[7] & state->PRG_mask;
-        bank_register[8] = ((state->bank_register[0] & 0xFE) + 1) & state->CHR_mask;
-        bank_register[9] = ((state->bank_register[1] & 0xFE) + 1) & state->CHR_mask;
-        if (state->CHR_ROM_bank_mode)
-        {
-            state->ptr_CHR_bank_1K[0] = getCHRBank(state, bank_register[2]);
-            state->ptr_CHR_bank_1K[1] = getCHRBank(state, bank_register[3]);
-            state->ptr_CHR_bank_1K[2] = getCHRBank(state, bank_register[4]);
-            state->ptr_CHR_bank_1K[3] = getCHRBank(state, bank_register[5]);
-            state->ptr_CHR_bank_1K[4] = getCHRBank(state, bank_register[0]);
-            state->ptr_CHR_bank_1K[5] = getCHRBank(state, bank_register[8]);
-            state->ptr_CHR_bank_1K[6] = getCHRBank(state, bank_register[1]);
-            state->ptr_CHR_bank_1K[7] = getCHRBank(state, bank_register[9]);
-        }
-        else
-        {
-            state->ptr_CHR_bank_1K[0] = getCHRBank(state, bank_register[0]);
-            state->ptr_CHR_bank_1K[1] = getCHRBank(state, bank_register[8]);
-            state->ptr_CHR_bank_1K[2] = getCHRBank(state, bank_register[1]);
-            state->ptr_CHR_bank_1K[3] = getCHRBank(state, bank_register[9]);
-            state->ptr_CHR_bank_1K[4] = getCHRBank(state, bank_register[2]);
-            state->ptr_CHR_bank_1K[5] = getCHRBank(state, bank_register[3]);
-            state->ptr_CHR_bank_1K[6] = getCHRBank(state, bank_register[4]);
-            state->ptr_CHR_bank_1K[7] = getCHRBank(state, bank_register[5]);
-        }
-
-        if (state->PRG_ROM_bank_mode)
-        {
-            state->ptr_PRG_bank_8K[0] = getPRGBank(state, (state->number_PRG_banks * 2) - 2);
-            state->ptr_PRG_bank_8K[2] = getPRGBank(state, bank_register[6]);
-        }
-        else
-        {
-            state->ptr_PRG_bank_8K[0] = getPRGBank(state, bank_register[6]);
-            state->ptr_PRG_bank_8K[2] = getPRGBank(state, (state->number_PRG_banks * 2) - 2);
-        }
-        state->ptr_PRG_bank_8K[1] = getPRGBank(state, bank_register[7]);
-        state->ptr_PRG_bank_8K[3] = getPRGBank(state, (state->number_PRG_banks * 2) - 1);
-        break;
-
-    // Mirroring (even address)
-    case 0xA000: state->cart->setMirrorMode(state->mirror[data & 0x01]); break;
-
-    // IRQ latch (even address) | IRQ reload (odd address)
-    case 0xC000: state->IRQ_latch = data; break;
-
-    case 0xC001: state->IRQ_counter = 0; break;
-
-    // IRQ disable (even address) | IRQ enable (odd address)
-    case 0xE000: state->IRQ_enable = false; break;
-
-    case 0xE001: state->IRQ_enable = true; break;
+        return;
     }
 
-    return false;
+    state->bank_register[state->bank_select] = data;
+
+    uint8_t bank_register[10];
+    bank_register[0] = (state->bank_register[0] & 0xFE) & state->CHR_mask;
+    bank_register[1] = (state->bank_register[1] & 0xFE) & state->CHR_mask;
+    bank_register[2] = state->bank_register[2] & state->CHR_mask;
+    bank_register[3] = state->bank_register[3] & state->CHR_mask;
+    bank_register[4] = state->bank_register[4] & state->CHR_mask;
+    bank_register[5] = state->bank_register[5] & state->CHR_mask;
+    bank_register[6] = state->bank_register[6] & state->PRG_mask;
+    bank_register[7] = state->bank_register[7] & state->PRG_mask;
+    bank_register[8] = ((state->bank_register[0] & 0xFE) + 1) & state->CHR_mask;
+    bank_register[9] = ((state->bank_register[1] & 0xFE) + 1) & state->CHR_mask;
+    if (state->CHR_ROM_bank_mode)
+    {
+        state->ptr_CHR_bank_1K[0] = getCHRBank(state, bank_register[2]);
+        state->ptr_CHR_bank_1K[1] = getCHRBank(state, bank_register[3]);
+        state->ptr_CHR_bank_1K[2] = getCHRBank(state, bank_register[4]);
+        state->ptr_CHR_bank_1K[3] = getCHRBank(state, bank_register[5]);
+        state->ptr_CHR_bank_1K[4] = getCHRBank(state, bank_register[0]);
+        state->ptr_CHR_bank_1K[5] = getCHRBank(state, bank_register[8]);
+        state->ptr_CHR_bank_1K[6] = getCHRBank(state, bank_register[1]);
+        state->ptr_CHR_bank_1K[7] = getCHRBank(state, bank_register[9]);
+    }
+    else
+    {
+        state->ptr_CHR_bank_1K[0] = getCHRBank(state, bank_register[0]);
+        state->ptr_CHR_bank_1K[1] = getCHRBank(state, bank_register[8]);
+        state->ptr_CHR_bank_1K[2] = getCHRBank(state, bank_register[1]);
+        state->ptr_CHR_bank_1K[3] = getCHRBank(state, bank_register[9]);
+        state->ptr_CHR_bank_1K[4] = getCHRBank(state, bank_register[2]);
+        state->ptr_CHR_bank_1K[5] = getCHRBank(state, bank_register[3]);
+        state->ptr_CHR_bank_1K[6] = getCHRBank(state, bank_register[4]);
+        state->ptr_CHR_bank_1K[7] = getCHRBank(state, bank_register[5]);
+    }
+
+    if (state->PRG_ROM_bank_mode)
+    {
+        state->ptr_PRG_bank_8K[0] = getPRGBank(state, (state->number_PRG_banks * 2) - 2);
+        state->ptr_PRG_bank_8K[2] = getPRGBank(state, bank_register[6]);
+    }
+    else
+    {
+        state->ptr_PRG_bank_8K[0] = getPRGBank(state, bank_register[6]);
+        state->ptr_PRG_bank_8K[2] = getPRGBank(state, (state->number_PRG_banks * 2) - 2);
+    }
+    state->ptr_PRG_bank_8K[1] = getPRGBank(state, bank_register[7]);
+    state->ptr_PRG_bank_8K[3] = getPRGBank(state, (state->number_PRG_banks * 2) - 1);
+
+    mapper004_remapWindows(state, bus);
+    return;
+}
+
+static void mapper004_mirrorWrite(Bus* bus, uint16_t addr, uint8_t data)
+{
+    Mapper004_state* state = (Mapper004_state*)bus->cart->mapper.state;
+    if (!(addr & 0x01)) state->cart->setMirrorMode(state->mirror[data & 0x01]);
+}
+
+static void mapper004_irqLatchWrite(Bus* bus, uint16_t addr, uint8_t data)
+{
+    Mapper004_state* state = (Mapper004_state*)bus->cart->mapper.state;
+    if (!(addr & 0x01)) state->IRQ_latch = data;
+    else state->IRQ_counter = 0;
+}
+
+static void mapper004_irqEnableWrite(Bus* bus, uint16_t addr, uint8_t data)
+{
+    Mapper004_state* state = (Mapper004_state*)bus->cart->mapper.state;
+    state->IRQ_enable = (addr & 0x01);
 }
 
 bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
@@ -228,6 +219,34 @@ void mapper004_reset(Mapper* mapper)
     state->PRG_mask = (state->number_PRG_banks * 2) - 1;
     state->CHR_mask = (state->number_CHR_banks * 8) - 1;
     state->cart->setMirrorMode(Cartridge::MIRROR::HORIZONTAL);
+}
+
+void mapper004_mapPages(Mapper* mapper, Bus* bus)
+{
+    Mapper004_state* state = (Mapper004_state*)mapper->state;
+
+    // $6000-$7FFF: 8KB PRG-RAM
+    for (int p = 0x60; p <= 0x7F; p++)
+    {
+        bus->read_pages[p] = state->RAM + ((p - 0x60) * 256);
+        bus->write_pages[p] = state->RAM + ((p - 0x60) * 256);
+    }
+
+    // Map bank writes
+    // $8000-$9FFF: Bank select (even address) | Bank data (odd address)
+    for (int p = 0x80; p <= 0x9F; p++) bus->write_handlers[p] = mapper004_bankWrite;
+
+    // $A000-$BFFF: Mirroring (even address)
+    for (int p = 0xA0; p <= 0xBF; p++) bus->write_handlers[p] = mapper004_mirrorWrite;
+
+    // $C000-$DFFF: IRQ latch (even address) | IRQ reload (odd address)
+    for (int p = 0xC0; p <= 0xDF; p++) bus->write_handlers[p] = mapper004_irqLatchWrite;
+
+    // $E000-$FFFF: IRQ disable (even address) | IRQ enable (odd address)
+    for (int p = 0xE0; p <= 0xFF; p++) bus->write_handlers[p] = mapper004_irqEnableWrite;
+
+    // Map bank reads
+    mapper004_remapWindows(state, bus);
 }
 
 void mapper004_dumpState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -145,16 +145,6 @@ static void mapper004_irqEnableWrite(Bus* bus, uint16_t addr, uint8_t data)
     state->IRQ_enable = (addr & 0x01);
 }
 
-bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper004_state* state = (Mapper004_state*)mapper->state;
-    uint8_t bank = (addr >> 10) & 0x07;
-    data = state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
-    return true;
-}
-
 void mapper004_scanline(Mapper* mapper)
 {
     Mapper004_state* state = (Mapper004_state*)mapper->state;

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -30,10 +30,9 @@ struct Mapper004_state
     uint16_t PRG_mask = 0;
     uint16_t CHR_mask = 0;
 
-    static constexpr Cartridge::MIRROR mirror[2] = { Cartridge::MIRROR::VERTICAL,
-                                                     Cartridge::MIRROR::HORIZONTAL };
+    static constexpr MIRROR mirror[2] = { MIRROR::VERTICAL, MIRROR::HORIZONTAL };
 };
-constexpr Cartridge::MIRROR Mapper004_state::mirror[2];
+constexpr MIRROR Mapper004_state::mirror[2];
 static inline uint8_t* getPRGBank(Mapper004_state* state, uint8_t index);
 static inline uint8_t* getCHRBank(Mapper004_state* state, uint8_t index);
 
@@ -218,7 +217,7 @@ void mapper004_reset(Mapper* mapper)
     state->CHR_ROM_bank_mode = 0;
     state->PRG_mask = (state->number_PRG_banks * 2) - 1;
     state->CHR_mask = (state->number_CHR_banks * 8) - 1;
-    state->cart->setMirrorMode(Cartridge::MIRROR::HORIZONTAL);
+    state->cart->setMirrorMode(MIRROR::HORIZONTAL);
 }
 
 void mapper004_mapPages(Mapper* mapper, Bus* bus)
@@ -260,7 +259,7 @@ void mapper004_dumpState(Mapper* mapper, File& state)
     state.write((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
     state.write((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
 
-    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+    MIRROR mirror = s->cart->getMirrorMode();
     state.write((uint8_t*)&mirror, sizeof(mirror));
 
     uint8_t PRG_bank_8K[4];
@@ -301,7 +300,7 @@ void mapper004_loadState(Mapper* mapper, File& state)
     state.read((uint8_t*)&s->IRQ_enable, sizeof(s->IRQ_enable));
     state.read((uint8_t*)&s->PRG_ROM_bank_mode, sizeof(s->PRG_ROM_bank_mode));
     state.read((uint8_t*)&s->CHR_ROM_bank_mode, sizeof(s->CHR_ROM_bank_mode));
-    Cartridge::MIRROR mirror;
+    MIRROR mirror;
     state.read((uint8_t*)&mirror, sizeof(mirror));
     s->cart->setMirrorMode(mirror);
 

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -49,15 +49,14 @@ static void mapper004_remapWindows(Mapper004_state* state, Bus* bus)
 
 static void mapper004_remapCHRPages(Mapper004_state* state, Ppu2C02* ppu)
 {
-    for (int b = 0; b < 8; b++)
+    uint8_t* windows[8] = { state->ptr_CHR_bank_1K[0], state->ptr_CHR_bank_1K[1],
+                            state->ptr_CHR_bank_1K[2], state->ptr_CHR_bank_1K[3],
+                            state->ptr_CHR_bank_1K[4], state->ptr_CHR_bank_1K[5],
+                            state->ptr_CHR_bank_1K[6], state->ptr_CHR_bank_1K[7] };
+    for (int i = 0; i < 8; i++)
     {
-        uint8_t* bank = state->ptr_CHR_bank_1K[b];
-        for (int i = 0; i < 4; i++)
-        {
-            int p = b * 4 + i;
-            ppu->ppu_read_pages[p] = bank + (i * 256);
-            ppu->ppu_write_pages[p] = nullptr;
-        }
+        int base = 0x00 + (i * 0x04);
+        for (int p = 0; p <= 0x03; p++) ppu->ppu_read_pages[base + p] = windows[i] + (p * 256);
     }
 }
 

--- a/src/core/mappers/mapper004.cpp
+++ b/src/core/mappers/mapper004.cpp
@@ -43,7 +43,21 @@ static void mapper004_remapWindows(Mapper004_state* state, Bus* bus)
     for (int i = 0; i < 4; i++)
     {
         int base = 0x80 + (i * 0x20);
-        for (int p = 0; p < 0x20; p++) bus->read_pages[base + p] = windows[i] + (p * 256);
+        for (int p = 0; p <= 0x1F; p++) bus->read_pages[base + p] = windows[i] + (p * 256);
+    }
+}
+
+static void mapper004_remapCHRPages(Mapper004_state* state, Ppu2C02* ppu)
+{
+    for (int b = 0; b < 8; b++)
+    {
+        uint8_t* bank = state->ptr_CHR_bank_1K[b];
+        for (int i = 0; i < 4; i++)
+        {
+            int p = b * 4 + i;
+            ppu->ppu_read_pages[p] = bank + (i * 256);
+            ppu->ppu_write_pages[p] = nullptr;
+        }
     }
 }
 
@@ -108,6 +122,7 @@ static void mapper004_bankWrite(Bus* bus, uint16_t addr, uint8_t data)
     state->ptr_PRG_bank_8K[3] = getPRGBank(state, (state->number_PRG_banks * 2) - 1);
 
     mapper004_remapWindows(state, bus);
+    mapper004_remapCHRPages(state, &bus->ppu);
     return;
 }
 
@@ -138,20 +153,6 @@ bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     uint8_t bank = (addr >> 10) & 0x07;
     data = state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
     return true;
-}
-
-bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    return false;
-}
-
-uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr)
-{
-    if (addr > 0x1FFF) return nullptr;
-
-    Mapper004_state* state = (Mapper004_state*)mapper->state;
-    uint8_t bank = (addr >> 10) & 0x07;
-    return &state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
 }
 
 void mapper004_scanline(Mapper* mapper)
@@ -288,6 +289,12 @@ void mapper004_dumpState(Mapper* mapper, File& state)
         state.write(s->RAM, 8U * 1024U);
         return;
     }
+}
+
+void mapper004_mapPPUPages(Mapper* mapper, Ppu2C02* ppu)
+{
+    Mapper004_state* state = (Mapper004_state*)mapper->state;
+    mapper004_remapCHRPages(state, ppu);
 }
 
 void mapper004_loadState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper004.h
+++ b/src/core/mappers/mapper004.h
@@ -10,9 +10,6 @@ Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend,
 
 void mapper004_mapPages(Mapper* mapper, Bus* bus);
 void mapper004_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
-bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr);
 void mapper004_scanline(Mapper* mapper);
 void mapper004_reset(Mapper* mapper);
 void mapper004_dumpState(Mapper* mapper, File& state);

--- a/src/core/mappers/mapper004.h
+++ b/src/core/mappers/mapper004.h
@@ -3,8 +3,8 @@
 
 #include "../mapper.h"
 
-#define MAPPER004_NUM_PRG_BANKS_8K 18
-#define MAPPER004_NUM_CHR_BANKS_1K 24
+#define MAPPER004_NUM_PRG_BANKS_8K 17
+#define MAPPER004_NUM_CHR_BANKS_1K 16
 
 Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 

--- a/src/core/mappers/mapper004.h
+++ b/src/core/mappers/mapper004.h
@@ -6,10 +6,10 @@
 #define MAPPER004_NUM_PRG_BANKS_8K 18
 #define MAPPER004_NUM_CHR_BANKS_1K 24
 
+class Bus;
 Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
-bool mapper004_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper004_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
+void mapper004_mapPages(Mapper* mapper, Bus* bus);
 bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper004.h
+++ b/src/core/mappers/mapper004.h
@@ -6,10 +6,10 @@
 #define MAPPER004_NUM_PRG_BANKS_8K 18
 #define MAPPER004_NUM_CHR_BANKS_1K 24
 
-class Bus;
 Mapper createMapper004(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
 void mapper004_mapPages(Mapper* mapper, Bus* bus);
+void mapper004_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
 bool mapper004_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
 bool mapper004_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
 uint8_t* mapper004_ppuReadPtr(Mapper* mapper, uint16_t addr);

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -62,6 +62,21 @@ static void mapper069_remapCHRPages(Mapper069_state* state, Ppu2C02* ppu)
     }
 }
 
+static void mapper069_remapRAMWindow(Mapper069_state* state, Bus* bus)
+{
+    // Read side: safe to point at ROM unconditionally when RAM is deselected
+    uint8_t* read_ptr = state->PRG_RAM_select ? state->RAM : state->ptr_PRG_bank_8K[0];
+    for (int p = 0x60; p <= 0x7F; p++) bus->read_pages[p] = read_ptr + ((p - 0x60) * 256);
+
+    // Write side: null falls through to mapper069_PRGWrite (no-op) when RAM disabled
+    for (int p = 0x60; p <= 0x7F; p++)
+    {
+        if (state->PRG_RAM_select && state->PRG_RAM_enable)
+            bus->write_pages[p] = state->RAM + ((p - 0x60) * 256);
+        else bus->write_pages[p] = nullptr;
+    }
+}
+
 static void mapper069_commandWrite(Bus* bus, uint16_t addr, uint8_t data)
 {
     Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
@@ -90,7 +105,7 @@ static void mapper069_parameterWrite(Bus* bus, uint16_t addr, uint8_t data)
         state->ptr_PRG_bank_8K[command & 0x03] = getPRGBank(state, (data & 0x3F) & state->PRG_mask);
         state->PRG_RAM_select = (data & 0x40) != 0;
         state->PRG_RAM_enable = (data & 0x80) != 0;
-        mapper069_remapWindows(state, bus);
+        mapper069_remapRAMWindow(state, bus);
         break;
 
     case 0x09:
@@ -109,33 +124,6 @@ static void mapper069_parameterWrite(Bus* bus, uint16_t addr, uint8_t data)
     case 0x0E: state->IRQ_counter = (state->IRQ_counter & 0xFF00) | data; break;
     case 0x0F: state->IRQ_counter = (state->IRQ_counter & 0x00FF) | (data << 8); break;
     }
-}
-
-static uint8_t mapper069_PRGRead(Bus* bus, uint16_t addr)
-{
-    Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
-
-    // PRG RAM
-    if (state->PRG_RAM_select && state->PRG_RAM_enable) return state->RAM[addr & 0x1FFF];
-
-    // PRG ROM
-    return state->ptr_PRG_bank_8K[0][addr & 0x1FFF];
-}
-
-static void mapper069_PRGWrite(Bus* bus, uint16_t addr, uint8_t data)
-{
-    Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
-    if (state->PRG_RAM_select && state->PRG_RAM_enable) state->RAM[addr & 0x1FFF] = data;
-}
-
-bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
-{
-    if (addr > 0x1FFF) return false;
-
-    Mapper069_state* state = (Mapper069_state*)mapper->state;
-    uint8_t bank = (addr >> 10) & 0x07;
-    data = state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
-    return true;
 }
 
 void mapper069_cycle(Mapper* mapper, int cycles)
@@ -209,11 +197,7 @@ void mapper069_mapPages(Mapper* mapper, Bus* bus)
     Mapper069_state* state = (Mapper069_state*)mapper->state;
 
     // $6000-$7FFF: PRG-ROM/PRG-RAM r/w
-    for (int p = 0x60; p <= 0x7F; p++)
-    {
-        bus->read_handlers[p] = mapper069_PRGRead;
-        bus->write_handlers[p] = mapper069_PRGWrite;
-    }
+    mapper069_remapRAMWindow(state, bus);
 
     // Command Register ($8000-$9FFF)
     for (int p = 0x80; p <= 0x9F; p++) bus->write_handlers[p] = mapper069_commandWrite;

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -29,12 +29,10 @@ struct Mapper069_state
     uint16_t PRG_mask = 0;
     uint16_t CHR_mask = 0;
 
-    static constexpr Cartridge::MIRROR mirror[4] = { Cartridge::MIRROR::VERTICAL,
-                                                     Cartridge::MIRROR::HORIZONTAL,
-                                                     Cartridge::MIRROR::ONESCREEN_LOW,
-                                                     Cartridge::MIRROR::ONESCREEN_HIGH };
+    static constexpr MIRROR mirror[4] = { MIRROR::VERTICAL, MIRROR::HORIZONTAL,
+                                          MIRROR::ONESCREEN_LOW, MIRROR::ONESCREEN_HIGH };
 };
-constexpr Cartridge::MIRROR Mapper069_state::mirror[4];
+constexpr MIRROR Mapper069_state::mirror[4];
 static inline uint8_t* getPRGBank(Mapper069_state* state, uint8_t index);
 static inline uint8_t* getCHRBank(Mapper069_state* state, uint8_t index);
 
@@ -206,7 +204,7 @@ void mapper069_reset(Mapper* mapper)
     state->PRG_RAM_enable = false;
     state->PRG_mask = (state->number_PRG_banks * 2) - 1;
     state->CHR_mask = (state->number_CHR_banks * 8) - 1;
-    state->cart->setMirrorMode(Cartridge::MIRROR::HORIZONTAL);
+    state->cart->setMirrorMode(MIRROR::HORIZONTAL);
 }
 
 void mapper069_dumpState(Mapper* mapper, File& state)
@@ -220,7 +218,7 @@ void mapper069_dumpState(Mapper* mapper, File& state)
     state.write((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
     state.write((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
 
-    Cartridge::MIRROR mirror = s->cart->getMirrorMode();
+    MIRROR mirror = s->cart->getMirrorMode();
     state.write((uint8_t*)&mirror, sizeof(mirror));
 
     uint8_t PRG_bank_8K[4];
@@ -260,7 +258,7 @@ void mapper069_loadState(Mapper* mapper, File& state)
     state.read((uint8_t*)&s->PRG_RAM_select, sizeof(s->PRG_RAM_select));
     state.read((uint8_t*)&s->PRG_RAM_enable, sizeof(s->PRG_RAM_enable));
 
-    Cartridge::MIRROR mirror;
+    MIRROR mirror;
     state.read((uint8_t*)&mirror, sizeof(mirror));
     s->cart->setMirrorMode(mirror);
 

--- a/src/core/mappers/mapper069.cpp
+++ b/src/core/mappers/mapper069.cpp
@@ -1,5 +1,7 @@
 #include "mapper069.h"
+#include "../bus.h"
 #include "../cartridge.h"
+#include "../ppu2C02.h"
 
 struct Mapper069_state
 {
@@ -36,85 +38,94 @@ constexpr MIRROR Mapper069_state::mirror[4];
 static inline uint8_t* getPRGBank(Mapper069_state* state, uint8_t index);
 static inline uint8_t* getCHRBank(Mapper069_state* state, uint8_t index);
 
-bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
+static void mapper069_remapWindows(Mapper069_state* state, Bus* bus)
 {
-    if (addr < 0x6000) return false;
-
-    Mapper069_state* state = (Mapper069_state*)mapper->state;
-    if (addr < 0x8000)
+    uint8_t* windows[4] = { state->ptr_PRG_bank_8K[1], state->ptr_PRG_bank_8K[2],
+                            state->ptr_PRG_bank_8K[3], state->ptr_PRG_bank_8K[4] };
+    for (int i = 0; i < 4; i++)
     {
-        // PRG RAM
-        if (state->PRG_RAM_select)
-        {
-            if (state->PRG_RAM_enable) data = state->RAM[addr & 0x1FFF];
-            return true;
-        }
-
-        // PRG ROM
-        data = state->ptr_PRG_bank_8K[0][addr & 0x1FFF];
-        return true;
+        int base = 0x80 + (i * 0x20);
+        for (int p = 0; p <= 0x1F; p++) bus->read_pages[base + p] = windows[i] + (p * 256);
     }
-
-    uint8_t bank = (addr >> 13) & 0x03;
-    data = state->ptr_PRG_bank_8K[bank + 1][addr & 0x1FFF];
-    return true;
 }
 
-bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
+static void mapper069_remapCHRPages(Mapper069_state* state, Ppu2C02* ppu)
 {
-    if (addr < 0x6000) return false;
-
-    Mapper069_state* state = (Mapper069_state*)mapper->state;
-    if (addr < 0x8000)
+    uint8_t* windows[8] = { state->ptr_CHR_bank_1K[0], state->ptr_CHR_bank_1K[1],
+                            state->ptr_CHR_bank_1K[2], state->ptr_CHR_bank_1K[3],
+                            state->ptr_CHR_bank_1K[4], state->ptr_CHR_bank_1K[5],
+                            state->ptr_CHR_bank_1K[6], state->ptr_CHR_bank_1K[7] };
+    for (int i = 0; i < 8; i++)
     {
-        if (state->PRG_RAM_select && state->PRG_RAM_enable) state->RAM[addr & 0x1FFF] = data;
-        return true;
+        int base = 0x00 + (i * 0x04);
+        for (int p = 0; p <= 0x03; p++) ppu->ppu_read_pages[base + p] = windows[i] + (p * 256);
     }
+}
 
-    // Command Register ($8000-$9FFF) | Parameter Register ($A000-$BFFF)
-    uint16_t masked_addr = addr & 0xE000;
-    if (masked_addr == 0x8000) state->command_register = data & 0x0F;
-    else if (masked_addr == 0xA000)
+static void mapper069_commandWrite(Bus* bus, uint16_t addr, uint8_t data)
+{
+    Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
+    state->command_register = data & 0x0F;
+}
+
+static void mapper069_parameterWrite(Bus* bus, uint16_t addr, uint8_t data)
+{
+    Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
+    uint8_t command = state->command_register;
+    switch (command)
     {
-        uint8_t command = state->command_register;
-        switch (command)
-        {
-        case 0x00:
-        case 0x01:
-        case 0x02:
-        case 0x03:
-        case 0x04:
-        case 0x05:
-        case 0x06:
-        case 0x07:
-            state->ptr_CHR_bank_1K[command] = getCHRBank(state, data & state->CHR_mask);
-            break;
+    case 0x00:
+    case 0x01:
+    case 0x02:
+    case 0x03:
+    case 0x04:
+    case 0x05:
+    case 0x06:
+    case 0x07:
+        state->ptr_CHR_bank_1K[command] = getCHRBank(state, data & state->CHR_mask);
+        mapper069_remapCHRPages(state, &bus->ppu);
+        break;
 
-        case 0x08:
-            state->ptr_PRG_bank_8K[command & 0x03] =
-                getPRGBank(state, (data & 0x3F) & state->PRG_mask);
-            state->PRG_RAM_select = (data & 0x40) != 0;
-            state->PRG_RAM_enable = (data & 0x80) != 0;
-            break;
+    case 0x08:
+        state->ptr_PRG_bank_8K[command & 0x03] = getPRGBank(state, (data & 0x3F) & state->PRG_mask);
+        state->PRG_RAM_select = (data & 0x40) != 0;
+        state->PRG_RAM_enable = (data & 0x80) != 0;
+        mapper069_remapWindows(state, bus);
+        break;
 
-        case 0x09:
-        case 0x0A:
-        case 0x0B:
-            state->ptr_PRG_bank_8K[command & 0x03] =
-                getPRGBank(state, (data & 0x3F) & state->PRG_mask);
-            break;
+    case 0x09:
+    case 0x0A:
+    case 0x0B:
+        state->ptr_PRG_bank_8K[command & 0x03] = getPRGBank(state, (data & 0x3F) & state->PRG_mask);
+        mapper069_remapWindows(state, bus);
+        break;
 
-        case 0x0C: state->cart->setMirrorMode(state->mirror[data & 0x03]); break;
+    case 0x0C: state->cart->setMirrorMode(state->mirror[data & 0x03]); break;
 
-        case 0x0D:
-            state->IRQ_enable = (data & 0x01) != 0;
-            state->IRQ_counter_enable = (data & 0x80) != 0;
-            break;
-        case 0x0E: state->IRQ_counter = (state->IRQ_counter & 0xFF00) | data; break;
-        case 0x0F: state->IRQ_counter = (state->IRQ_counter & 0x00FF) | (data << 8); break;
-        }
+    case 0x0D:
+        state->IRQ_enable = (data & 0x01) != 0;
+        state->IRQ_counter_enable = (data & 0x80) != 0;
+        break;
+    case 0x0E: state->IRQ_counter = (state->IRQ_counter & 0xFF00) | data; break;
+    case 0x0F: state->IRQ_counter = (state->IRQ_counter & 0x00FF) | (data << 8); break;
     }
-    return false;
+}
+
+static uint8_t mapper069_PRGRead(Bus* bus, uint16_t addr)
+{
+    Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
+
+    // PRG RAM
+    if (state->PRG_RAM_select && state->PRG_RAM_enable) return state->RAM[addr & 0x1FFF];
+
+    // PRG ROM
+    return state->ptr_PRG_bank_8K[0][addr & 0x1FFF];
+}
+
+static void mapper069_PRGWrite(Bus* bus, uint16_t addr, uint8_t data)
+{
+    Mapper069_state* state = (Mapper069_state*)bus->cart->mapper.state;
+    if (state->PRG_RAM_select && state->PRG_RAM_enable) state->RAM[addr & 0x1FFF] = data;
 }
 
 bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
@@ -125,20 +136,6 @@ bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data)
     uint8_t bank = (addr >> 10) & 0x07;
     data = state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
     return true;
-}
-
-bool mapper069_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data)
-{
-    return false;
-}
-
-uint8_t* mapper069_ppuReadPtr(Mapper* mapper, uint16_t addr)
-{
-    if (addr > 0x1FFF) return nullptr;
-
-    Mapper069_state* state = (Mapper069_state*)mapper->state;
-    uint8_t bank = (addr >> 10) & 0x07;
-    return &state->ptr_CHR_bank_1K[bank][addr & 0x03FF];
 }
 
 void mapper069_cycle(Mapper* mapper, int cycles)
@@ -205,6 +202,33 @@ void mapper069_reset(Mapper* mapper)
     state->PRG_mask = (state->number_PRG_banks * 2) - 1;
     state->CHR_mask = (state->number_CHR_banks * 8) - 1;
     state->cart->setMirrorMode(MIRROR::HORIZONTAL);
+}
+
+void mapper069_mapPages(Mapper* mapper, Bus* bus)
+{
+    Mapper069_state* state = (Mapper069_state*)mapper->state;
+
+    // $6000-$7FFF: PRG-ROM/PRG-RAM r/w
+    for (int p = 0x60; p <= 0x7F; p++)
+    {
+        bus->read_handlers[p] = mapper069_PRGRead;
+        bus->write_handlers[p] = mapper069_PRGWrite;
+    }
+
+    // Command Register ($8000-$9FFF)
+    for (int p = 0x80; p <= 0x9F; p++) bus->write_handlers[p] = mapper069_commandWrite;
+
+    // Parameter Register ($A000-$BFFF)
+    for (int p = 0xA0; p <= 0xBF; p++) bus->write_handlers[p] = mapper069_parameterWrite;
+
+    // Map bank reads
+    mapper069_remapWindows(state, bus);
+}
+
+void mapper069_mapPPUPages(Mapper* mapper, Ppu2C02* ppu)
+{
+    Mapper069_state* state = (Mapper069_state*)mapper->state;
+    mapper069_remapCHRPages(state, ppu);
 }
 
 void mapper069_dumpState(Mapper* mapper, File& state)

--- a/src/core/mappers/mapper069.h
+++ b/src/core/mappers/mapper069.h
@@ -4,7 +4,7 @@
 #include "../mapper.h"
 
 #define MAPPER069_NUM_PRG_BANKS_8K 17
-#define MAPPER069_NUM_CHR_BANKS_1K 24
+#define MAPPER069_NUM_CHR_BANKS_1K 20
 
 Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 

--- a/src/core/mappers/mapper069.h
+++ b/src/core/mappers/mapper069.h
@@ -8,11 +8,8 @@
 
 Mapper createMapper069(uint8_t PRG_banks, uint8_t CHR_banks, ROMBackend backend, Cartridge* cart);
 
-bool mapper069_cpuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper069_cpuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-bool mapper069_ppuRead(Mapper* mapper, uint16_t addr, uint8_t& data);
-bool mapper069_ppuWrite(Mapper* mapper, uint16_t addr, uint8_t data);
-uint8_t* mapper069_ppuReadPtr(Mapper* mapper, uint16_t addr);
+void mapper069_mapPages(Mapper* mapper, Bus* bus);
+void mapper069_mapPPUPages(Mapper* mapper, Ppu2C02* ppu);
 void mapper069_cycle(Mapper* mapper, int cycles);
 void mapper069_reset(Mapper* mapper);
 void mapper069_dumpState(Mapper* mapper, File& state);

--- a/src/core/mirror_mode.h
+++ b/src/core/mirror_mode.h
@@ -1,0 +1,14 @@
+#ifndef MIRROR_MODE_H
+#define MIRROR_MODE_H
+#include <cstdint>
+
+enum class MIRROR : uint8_t
+{
+    HORIZONTAL,
+    VERTICAL,
+    ONESCREEN_LOW,
+    ONESCREEN_HIGH,
+    HARDWARE
+};
+
+#endif

--- a/src/core/ppu2C02.cpp
+++ b/src/core/ppu2C02.cpp
@@ -524,7 +524,7 @@ inline void Ppu2C02::finishScanline()
     uint16_t* display = ptr_display + ((uint32_t)scanline_counter * SCANLINE_SIZE);
     #endif
     uint8_t* buffer = ptr_buffer;
-    for (int i = 0; i < SCANLINE_SIZE; i++) display[i] = nes_palette[mask.emphasize][buffer[i]];
+    for (int i = 0; i < SCANLINE_SIZE; i++) display[i] = palette_NTSC565[0][buffer[i]];
 
     scanline_counter++;
     if (scanline_counter >= SCANLINES_PER_BUFFER)

--- a/src/core/ppu2C02.cpp
+++ b/src/core/ppu2C02.cpp
@@ -1,5 +1,6 @@
 #include "ppu2C02.h"
 #include "bus.h"
+#include "cartridge.h"
 
 #define READ_PALETTE(x) palette_table[((x) & 0x1F) ^ (((x) & 0x13) == 0x10 ? 0x10 : 0x00)]
 
@@ -48,44 +49,26 @@ Ppu2C02::~Ppu2C02()
 inline void Ppu2C02::ppuWrite(uint16_t addr, uint8_t data)
 {
     addr &= 0x3FFF;
-
-    if (cart->ppuWrite(addr, data)) return;
-    else if (addr >= 0x2000 && addr <= 0x3EFF)
+    if (uint8_t* p = ppu_write_pages[addr >> 8])
     {
-        ptr_nametable[(addr >> 10) & 3][addr & 0x03FF] = data;
+        p[addr & 0xFF] = data;
+        return;
     }
-    else if (addr >= 0x3F00 && addr <= 0x3FFF)
-    {
-        addr = palette_mirror[addr & 0x001F];
-        palette_table[addr] = data;
-    }
+    ppu_write_handlers[addr >> 8](this, addr, data);
 }
 
 inline uint8_t Ppu2C02::ppuRead(uint16_t addr)
 {
-    uint8_t data = 0x00;
     addr &= 0x3FFF;
+    if (uint8_t* p = ppu_read_pages[addr >> 8]) return p[addr & 0xFF];
+    return ppu_read_handlers[addr >> 8](this, addr);
+}
 
-    if (cart->ppuRead(addr, data)) return data;
-    else if (addr >= 0x2000 && addr <= 0x3EFF)
-    {
-        data = ptr_nametable[(addr >> 10) & 3][addr & 0x03FF];
-    }
-    else if (addr >= 0x3F00 && addr <= 0x3FFF)
-    {
-        addr &= 0x001F;
-        switch (addr)
-        {
-        case 0x0010: addr = 0x0000; break;
-        case 0x0014: addr = 0x0004; break;
-        case 0x0018: addr = 0x0008; break;
-        case 0x001C: addr = 0x000C; break;
-        default: break;
-        }
-        data = palette_table[addr] & (mask.grayscale ? 0x30 : 0x3F);
-    }
-
-    return data;
+inline uint8_t* Ppu2C02::ppuReadPtr(uint16_t addr)
+{
+    addr &= 0x3FFF;
+    if (uint8_t* p = ppu_read_pages[addr >> 8]) return p + (addr & 0xFF);
+    return nullptr;
 }
 
 IRAM_ATTR void Ppu2C02::cpuWrite(uint16_t addr, uint8_t data)
@@ -253,7 +236,7 @@ inline void Ppu2C02::renderBackground()
     for (int tile = 0; tile < 33; tile++)
     {
         tile_index = *ptr_tile++;
-        ptr_pattern_tile = cart->ppuReadPtr(offset + (tile_index << 4));
+        ptr_pattern_tile = ppuReadPtr(offset + (tile_index << 4));
 
         // draw to framebuffer
         uint16_t pattern = ((ptr_pattern_tile[8] & 0xAA) << 8) |
@@ -341,7 +324,7 @@ inline void Ppu2C02::renderSprites()
         // If 8x16 sprite mode
         tile_addr = (control.sprite_size) ? ((tile_index & 0x01) << 12) | ((tile_index & 0xFE) << 4)
                                           : offset + (tile_index << 4);
-        ptr_tile = cart->ppuReadPtr(tile_addr);
+        ptr_tile = ppuReadPtr(tile_addr);
 
         y_offset = (int16_t)(scanline - sprite_y);
         if (y_offset > 7) y_offset += 8;
@@ -458,7 +441,7 @@ void Ppu2C02::fakeSpriteHit(uint16_t current_scanline)
 
     tile_addr = (control.sprite_size) ? ((tile_index & 0x01) << 12) | ((tile_index & 0xFE) << 4)
                                       : offset + (tile_index << 4);
-    uint8_t* ptr_tile = cart->ppuReadPtr(tile_addr);
+    uint8_t* ptr_tile = ppuReadPtr(tile_addr);
 
     y_offset = (int16_t)(scanline - sprite_y);
     if (y_offset > 7) y_offset += 8;
@@ -557,62 +540,116 @@ void Ppu2C02::reset()
     PPUDATA_buffer = 0x00;
 }
 
+void Ppu2C02::buildPPUPageTables()
+{
+    for (int p = 0; p <= 0x3F; p++)
+    {
+        ppu_read_pages[p] = nullptr;
+        ppu_write_handlers[p] = nullptr;
+        ppu_read_handlers[p] = defaultPPUReadHandler;
+        ppu_write_handlers[p] = defaultPPUWriteHandler;
+    }
+
+    // $2000-3EFF: Nametables
+    remapNametablePages();
+
+    // $3F00-3FFF: Palettes
+    ppu_read_pages[0x3F] = nullptr;
+    ppu_write_pages[0x3F] = nullptr;
+    ppu_read_handlers[0x3F] = paletteReadHandler;
+    ppu_write_handlers[0x3F] = paletteWriteHandler;
+}
+
+void Ppu2C02::remapNametablePages()
+{
+    for (int p = 0x20; p <= 0x3E; p++)
+    {
+        int quadrant = (p >> 2) & 3;
+        int offset = (p & 3) * PPU_PAGE_SIZE;
+        ppu_read_pages[p] = ptr_nametable[quadrant] + offset;
+        ppu_write_pages[p] = ptr_nametable[quadrant] + offset;
+    }
+}
+
+uint8_t Ppu2C02::paletteReadHandler(Ppu2C02* ppu, uint16_t addr)
+{
+    addr = ppu->palette_mirror[addr & 0x001F];
+    return ppu->palette_table[addr] & (ppu->mask.grayscale ? 0x30 : 0x3F);
+}
+
+void Ppu2C02::paletteWriteHandler(Ppu2C02* ppu, uint16_t addr, uint8_t data)
+{
+    addr = ppu->palette_mirror[addr & 0x001F];
+    ppu->palette_table[addr] = data;
+}
+
+uint8_t Ppu2C02::defaultPPUReadHandler(Ppu2C02* ppu, uint16_t addr)
+{
+    return 0x00;
+}
+
+void Ppu2C02::defaultPPUWriteHandler(Ppu2C02* ppu, uint16_t addr, uint8_t data)
+{
+    return;
+}
+
 void Ppu2C02::connectCartridge(Cartridge* cartridge)
 {
     cart = cartridge;
-    setMirror((Cartridge::MIRROR)cart->hardware_mirror);
+    setMirror((MIRROR)cart->hardware_mirror);
 }
 
-void Ppu2C02::setMirror(Cartridge::MIRROR mirror)
+void Ppu2C02::setMirror(MIRROR mirror)
 {
     switch (mirror)
     {
-    case Cartridge::MIRROR::VERTICAL:
+    case MIRROR::VERTICAL:
         ptr_nametable[0] = &nametable[0x0000];
         ptr_nametable[1] = &nametable[0x0400];
         ptr_nametable[2] = &nametable[0x0000];
         ptr_nametable[3] = &nametable[0x0400];
         break;
 
-    case Cartridge::MIRROR::HORIZONTAL:
+    case MIRROR::HORIZONTAL:
         ptr_nametable[0] = &nametable[0x0000];
         ptr_nametable[1] = &nametable[0x0000];
         ptr_nametable[2] = &nametable[0x0400];
         ptr_nametable[3] = &nametable[0x0400];
         break;
 
-    case Cartridge::MIRROR::ONESCREEN_LOW:
+    case MIRROR::ONESCREEN_LOW:
         ptr_nametable[0] = ptr_nametable[1] = ptr_nametable[2] = ptr_nametable[3] =
             &nametable[0x0000];
         break;
 
-    case Cartridge::MIRROR::ONESCREEN_HIGH:
+    case MIRROR::ONESCREEN_HIGH:
         ptr_nametable[0] = ptr_nametable[1] = ptr_nametable[2] = ptr_nametable[3] =
             &nametable[0x0400];
         break;
     default: break;
     }
+    remapNametablePages();
 }
 
-Cartridge::MIRROR Ppu2C02::getMirror()
+MIRROR Ppu2C02::getMirror()
 {
     if (ptr_nametable[0] == &nametable[0x0000] && ptr_nametable[1] == &nametable[0x0000] &&
         ptr_nametable[2] == &nametable[0x0400] && ptr_nametable[3] == &nametable[0x0400])
-        return Cartridge::MIRROR::HORIZONTAL;
+        return MIRROR::HORIZONTAL;
 
     else if (ptr_nametable[0] == &nametable[0x0000] && ptr_nametable[1] == &nametable[0x0400] &&
              ptr_nametable[2] == &nametable[0x0000] && ptr_nametable[3] == &nametable[0x0400])
-        return Cartridge::MIRROR::VERTICAL;
+        return MIRROR::VERTICAL;
 
     else if (ptr_nametable[0] == &nametable[0x0000] && ptr_nametable[1] == &nametable[0x0000] &&
              ptr_nametable[2] == &nametable[0x0000] && ptr_nametable[3] == &nametable[0x0000])
-        return Cartridge::MIRROR::ONESCREEN_LOW;
+        return MIRROR::ONESCREEN_LOW;
 
     else if (ptr_nametable[0] == &nametable[0x0400] && ptr_nametable[1] == &nametable[0x0400] &&
              ptr_nametable[2] == &nametable[0x0400] && ptr_nametable[3] == &nametable[0x0400])
-        return Cartridge::MIRROR::ONESCREEN_HIGH;
+        return MIRROR::ONESCREEN_HIGH;
 
-    return Cartridge::MIRROR::HORIZONTAL;
+    return MIRROR::HORIZONTAL;
 }
 
 void Ppu2C02::setPalette(uint8_t palette)

--- a/src/core/ppu2C02.h
+++ b/src/core/ppu2C02.h
@@ -8,7 +8,7 @@
 #include "cartridge.h"
 #include "mirror_mode.h"
 
-#define BUFFER_SIZE          (256 + 8 + 8)
+#define BUFFER_SIZE          (256 + 8)
 #define SCANLINE_SIZE        256
 #define SCANLINES_PER_BUFFER 8
 #define TILES_PER_SCANLINE   32

--- a/src/core/ppu2C02.h
+++ b/src/core/ppu2C02.h
@@ -6,6 +6,7 @@
 
 #include "../../config.h"
 #include "cartridge.h"
+#include "mirror_mode.h"
 
 #define BUFFER_SIZE          (256 + 8 + 8)
 #define SCANLINE_SIZE        256
@@ -22,6 +23,7 @@
     #define SCANLINES_PER_BUFFER 4
 #endif
 
+class Cartridge;
 class Bus;
 class Ppu2C02
 {
@@ -29,9 +31,22 @@ public:
     Ppu2C02();
     ~Ppu2C02();
 
-public:
+    static constexpr int PPU_PAGE_SIZE = 256;
+    static constexpr int NUM_PPU_PAGES = 0x4000 / PPU_PAGE_SIZE;
+    using PPUReadHandler = uint8_t (*)(Ppu2C02*, uint16_t);
+    using PPUWriteHandler = void (*)(Ppu2C02*, uint16_t, uint8_t);
+
+    uint8_t* ppu_read_pages[NUM_PPU_PAGES] = {};
+    uint8_t* ppu_write_pages[NUM_PPU_PAGES] = {};
+    PPUReadHandler ppu_read_handlers[NUM_PPU_PAGES] = {};
+    PPUWriteHandler ppu_write_handlers[NUM_PPU_PAGES] = {};
+
+    void buildPPUPageTables();
+    void remapNametablePages();
+
     void ppuWrite(uint16_t addr, uint8_t data);
     uint8_t ppuRead(uint16_t addr);
+    uint8_t* ppuReadPtr(uint16_t addr);
     void cpuWrite(uint16_t addr, uint8_t data);
     uint8_t cpuRead(uint16_t addr);
 
@@ -47,8 +62,8 @@ public:
     }
     void connectCartridge(Cartridge* cartridge);
     void connectFramebuffer(uint8_t* framebuffer);
-    void setMirror(Cartridge::MIRROR mirror);
-    Cartridge::MIRROR getMirror();
+    void setMirror(MIRROR mirror);
+    MIRROR getMirror();
 
     void dumpState(File& state);
     void loadState(File& state);
@@ -859,6 +874,11 @@ private:
     // Rendering
     uint16_t scanline = 0x00;
     uint8_t* ptr_scanline_meta = nullptr;
+
+    static uint8_t paletteReadHandler(Ppu2C02* ppu, uint16_t addr);
+    static void paletteWriteHandler(Ppu2C02* ppu, uint16_t addr, uint8_t data);
+    static uint8_t defaultPPUReadHandler(Ppu2C02* ppu, uint16_t addr);
+    static void defaultPPUWriteHandler(Ppu2C02* ppu, uint16_t addr, uint8_t data);
 
 public:
     uint8_t* ptr_sprite = (uint8_t*)sprite;

--- a/src/core/ppu2C02.h
+++ b/src/core/ppu2C02.h
@@ -9,7 +9,7 @@
 
 #define BUFFER_SIZE          (256 + 8 + 8)
 #define SCANLINE_SIZE        256
-#define SCANLINES_PER_BUFFER 8
+#define SCANLINES_PER_BUFFER 120
 #define TILES_PER_SCANLINE   32
 #define PIXELS_PER_TILE      8
 

--- a/src/core/ppu2C02.h
+++ b/src/core/ppu2C02.h
@@ -10,7 +10,7 @@
 
 #define BUFFER_SIZE          (256 + 8 + 8)
 #define SCANLINE_SIZE        256
-#define SCANLINES_PER_BUFFER 120
+#define SCANLINES_PER_BUFFER 8
 #define TILES_PER_SCANLINE   32
 #define PIXELS_PER_TILE      8
 

--- a/src/core/ppu2C02.h
+++ b/src/core/ppu2C02.h
@@ -8,7 +8,7 @@
 #include "cartridge.h"
 #include "mirror_mode.h"
 
-#define BUFFER_SIZE          (256 + 8)
+#define BUFFER_SIZE          (256 + 8 + 8)
 #define SCANLINE_SIZE        256
 #define SCANLINES_PER_BUFFER 8
 #define TILES_PER_SCANLINE   32


### PR DESCRIPTION
## Overview
Replaces per-access mapper dispatch (`cart->cpuRead`/`cpuWrite`, switch on
mapper_ID, called unconditionally on every bus access) with a 256-entry
LUT (lookup table) indexed by `addr >> 8`. RAM/ROM/banked regions get
direct pointers; PPU/APU/mapper-register regions get function-pointer
handlers, dispatched in O(1) instead of walking a if-chain.

CPU-side and PPU-side bus LUT dispatch done for all mappers (000, 001,
002, 003, 004, 069). `Cartridge::cpuRead`/`cpuWrite` and the
mapperNNN_cpuRead/cpuWrite switch-dispatch functions have been
removed.

## Why
Profiling with the old if-chain dispatch showed
`bus::cpuRead` at 38.56% of total cycles (613M/interval). Within that,
`cart::cpuRead` alone accounted for 17.61% (280M cycles), called
unconditionally on every single bus read with 6,433,651 calls, exactly
matching `bus::cpuRead`'s hit count, regardless of whether the address
was even cartridge space. Direct pointer indexing for RAM/ROM
eliminates that call entirely for the majority of accesses; LUT handler
dispatch replaces branching if-chains for the remaining MMIO/register
writes.

The old dispatch was effectively O(n) in the number of address ranges
checked. Each read/write walked a sequence of comparisons (`addr >=
0x0000 && addr <= 0x1FFF`, `addr == 0x4014`, mapper_ID switch, etc.) until it found a
match, with cost scaling with how many ranges existed before the right
one. LUT dispatch replaces this with a direct array index:
`readPages[addr >> 8]` / `writeHandlers[addr >> 8]`, which is O(1)
regardless of how many mappers or address ranges are registered: the
cost of resolving an access doesn't grow as more mappers get ported to
this scheme. LUT handler dispatch replaces the remaining branching logic for MMIO/register
writes with a single indirect function call selected by the same O(1) lookup.

## Results
All mappers confirmed sustaining >60fps with no frame skip. Mappers currently only confirmed working with flash mode.

## Remaining work before merge
- [x] Port mapper003 to LUT dispatch
- [x] Port mapper069 to LUT dispatch
- [x] PPU LUT dispatch (`ppuRead`/`ppuWrite`/`ppuReadPtr`)
- [x] Remove `Cartridge::cpuRead`/`cpuWrite` and all `mapperNNN_cpuRead`/
      `cpuWrite` functions once every mapper is covered on both buses
- [x] Add display-dependent frameskip option: skip frames on 40MHz-SPI
      displays (e.g. ILI9341), no frameskip on 80MHz-SPI displays (e. g. ST7789)

## Testing
- [x] mapper000 ROM
- [x] mapper001 ROM
- [x] mapper002 ROM
- [x] mapper003 ROM
- [x] mapper004 ROM
- [x] mapper069 ROM
- [x] All mappers work with both RAM mode and Flash mode
- [x] PPU LUT dispatch